### PR TITLE
Cleanup: Rename to `chainguard-dev`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 🚨 **This is a work in progress.** 🚨
 
-https://registry.terraform.io/providers/mattmoor/cosign
+https://registry.terraform.io/providers/chainguard-dev/cosign
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mattmoor/terraform-provider-cosign
+module github.com/chainguard-dev/terraform-provider-cosign
 
 go 1.19
 

--- a/internal/provider/resource_sign_test.go
+++ b/internal/provider/resource_sign_test.go
@@ -37,7 +37,7 @@ resource "cosign_verify" "bar" {
           url = "https://fulcio.sigstore.dev"
           identities = [{
             issuer  = "https://token.actions.githubusercontent.com"
-            subject = "https://github.com/mattmoor/terraform-provider-cosign/.github/workflows/test.yml@refs/heads/main"
+            subject = "https://github.com/chainguard-dev/terraform-provider-cosign/.github/workflows/test.yml@refs/heads/main"
           }]
         }
         ctlog = {

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 
+	"github.com/chainguard-dev/terraform-provider-cosign/internal/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/mattmoor/terraform-provider-cosign/internal/provider"
 )
 
 // Run "go generate" to format example terraform files and generate the docs for the registry/website
@@ -36,7 +36,7 @@ func main() {
 		Debug: debugMode,
 
 		// TODO: update this string with the full name of your provider as used in your configs
-		ProviderAddr: "registry.terraform.io/mattmoor/cosign",
+		ProviderAddr: "registry.terraform.io/chainguard-dev/cosign",
 
 		ProviderFunc: provider.New(version),
 	}


### PR DESCRIPTION
:broom: This renames `mattmoor` -> `chainguard-dev` to reflect the repo transfer.

/kind cleanup