### PR TITLE
Feature: Have `cosign_sign` warn when ambient credentials are missing.

### DIFF
--- a/internal/provider/resource_sign.go
+++ b/internal/provider/resource_sign.go
@@ -51,7 +51,12 @@ func resourceCosignSignCreate(ctx context.Context, d *schema.ResourceData, _ int
 	}
 
 	if !providers.Enabled(ctx) {
-		return diag.Errorf("no ambient credentials are available to sign with.")
+		d.Set("signed_ref", digest.String())
+		d.SetId(digest.String())
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "no ambient credentials are available to sign with, skipping signing.",
+		}}
 	}
 
 	// TODO(mattmoor): Move these to be configuration options.


### PR DESCRIPTION
:gift: This makes the absence of ambient credentials non-fatal at deploy time, which is a nice balance for use cases that don't want signing when deploying from a workstation, but do from release automation (e.g. a shared module btw dev envs and producation).  This can be made fatal by threading the image through `cosign_verify`, and in the future we might make this a knob (with diff defaults), but this feels like a reasonable balance to start.

/kind feature