### PR TITLE
Add option to define fulcio and rekor url

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @hashicorp/terraform-devex

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,5 +1,0 @@
-# Code of Conduct
-
-HashiCorp Community Guidelines apply to you when interacting with the community here on GitHub and contributing code.
-
-Please read the full text at https://www.hashicorp.com/community-guidelines

--- a/docs/resources/attest.md
+++ b/docs/resources/attest.md
@@ -21,6 +21,11 @@ This attests the provided image digest with cosign.
 - `predicate` (String) The JSON body of the in-toto predicate's claim.
 - `predicate_type` (String) The in-toto predicate type of the claim being attested.
 
+### Optional
+
+- `fulcio_url` (String) Address of sigstore PKI server (default https://fulcio.sigstore.dev).
+- `rekor_url` (String) Address of rekor transparency log server (default https://rekor.sigstore.dev).
+
 ### Read-Only
 
 - `attested_ref` (String) This always matches the input digest, but is a convenience for composition.

--- a/docs/resources/sign.md
+++ b/docs/resources/sign.md
@@ -19,6 +19,11 @@ This signs the provided image digest with cosign.
 
 - `image` (String) The digest of the container image to sign.
 
+### Optional
+
+- `fulcio_url` (String) Address of sigstore PKI server (default https://fulcio.sigstore.dev).
+- `rekor_url` (String) Address of rekor transparency log server (default https://rekor.sigstore.dev).
+
 ### Read-Only
 
 - `id` (String) The immutable digest this resource signs.

--- a/internal/provider/resource_sign_test.go
+++ b/internal/provider/resource_sign_test.go
@@ -47,6 +47,19 @@ func TestAccResourceCosignSign(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	img3, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dig3, err := img3.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref3 := repo.Digest(dig3.String())
+	if err := remote.Write(ref3, img3); err != nil {
+		t.Fatal(err)
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
Now can set Fulcio and Rekor in the resource level

example
```
resource "cosign_sign" "foo" {
  image = blabla/xoxo@sha256:23432432

  fulcio_url = "https://my_custom_fulcio"
  rekor_url = "https://my_custom_rekor"
}
```


However running the tests and running `cosign` itself and point for example to rekor/fulcio at staging env it return the error

```
Error: signing [ghcr.io/cpanato/testing-ci-providers:latest]: getting signer: getting key from Fulcio: verifying SCT: ctfe public key not found for payload. Check your TUF root (see cosign initialize) or set a custom key with env var SIGSTORE_CT_LOG_PUBLIC_KEY_FILE
main.go:74: error during command execution: signing [ghcr.io/cpanato/testing-ci-providers:latest]: getting signer: getting key from Fulcio: verifying SCT: ctfe public key not found for payload. Check your TUF root (see cosign initialize) or set a custom key with env var SIGSTORE_CT_LOG_PUBLIC_KEY_FILE
```

So looks like we need to run the cosign initialize first

Fixes: #8 