### PR TITLE
Revert annotations to be nil

### DIFF
--- a/internal/provider/resource_sign.go
+++ b/internal/provider/resource_sign.go
@@ -128,7 +128,7 @@ func (r *SignResource) doSign(ctx context.Context, data *SignResourceModel) (str
 	defer cancel()
 
 	// TODO: This should probably be configurable?
-	annotations := map[string]interface{}{}
+	var annotations map[string]interface{} = nil
 
 	if err := secant.Sign(ctx, annotations, sv, rekorClient, []string{digest.String()}, r.popts.ropts); err != nil {
 		return "", nil, fmt.Errorf("Unable to sign image: %w", err)


### PR DESCRIPTION
Looks like this gets serialized as "null" in the previous path, but I had this as an empty map, which gets serialized as "{}", so let's revert this to match what we had before.