### PR TITLE
Wire up ggcr logs warning and debug logs

### DIFF
--- a/internal/secant/attest.go
+++ b/internal/secant/attest.go
@@ -7,12 +7,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/url"
 
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant/models/intoto"
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant/tlog"
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant/types"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -113,8 +113,8 @@ func Attest(ctx context.Context, statement *types.Statement, sv types.CosignerSi
 		return fmt.Errorf("creating intoto entry: %w", err)
 	}
 
-	log.Printf("debug envelope:\n%s", string(envelope))
-	log.Printf("debug rawCert:\n%s", string(rawCert))
+	logs.Debug.Printf("debug envelope:\n%s", envelope)
+	logs.Debug.Printf("debug rawCert:\n%s", rawCert)
 
 	entry, err := tlog.Upload(ctx, rekorClient, e)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"flag"
 	"log"
+	"os"
 
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/provider"
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 
@@ -22,6 +24,13 @@ func main() {
 	opts := providerserver.ServeOpts{
 		Address: "registry.terraform.io/chainguard-dev/cosign",
 		Debug:   debug,
+	}
+
+	// Wire up ggcr logs.
+	logs.Warn.SetOutput(os.Stderr)
+	if debug {
+		logs.Progress.SetOutput(os.Stderr)
+		logs.Debug.SetOutput(os.Stderr)
 	}
 
 	if err := providerserver.Serve(context.Background(), provider.New(version), opts); err != nil {


### PR DESCRIPTION
We always want logs.Warn wired up so we can see if transient failures are actually being retried, but logs.Debug and logs.Progress are only wired up if terraform passes us the debug flag.