### PR TITLE
Allow disabling signing/attesting with env var.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ See provider examples:
 - [ECS](./provider-examples/ecs/README.md)
 
 
-
 This provider also exposes `cosign_sign` and `cosign_attest` resources that will
 sign and attest a provided OCI digest, which is intended to compose with
 OCI providers such as [`ko`](https://github.com/ko-build/terraform-provider-ko),
@@ -56,3 +55,9 @@ resource "cosign_attest" "example" {
 # Reference cosign_attest.example.attested_ref to ensure we wait for all of the
 # metadata to be published.
 ```
+
+## Disabling
+
+The provider will skip signing/attesting when ambient credentials are not
+present, but can also be explicitly disabled by setting `TF_COSIGN_DISABLE` to
+any value.

--- a/internal/provider/resource_attest.go
+++ b/internal/provider/resource_attest.go
@@ -176,6 +176,9 @@ func (r *AttestResource) doAttest(ctx context.Context, data *AttestResourceModel
 		return "", nil, errors.New("unable to parse image digest")
 	}
 
+	if os.Getenv("TF_COSIGN_DISABLE") != "" {
+		return digest.String(), errors.New("TF_COSIGN_DISABLE is set, skipping attesting"), nil
+	}
 	if !r.popts.oidc.Enabled(ctx) {
 		return digest.String(), errors.New("no ambient credentials are available to attest with, skipping attesting"), nil
 	}

--- a/internal/provider/resource_sign.go
+++ b/internal/provider/resource_sign.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant"
 	"github.com/chainguard-dev/terraform-provider-oci/pkg/validators"
@@ -107,8 +108,11 @@ func (r *SignResource) doSign(ctx context.Context, data *SignResourceModel) (str
 		return "", nil, errors.New("Unable to parse image digest")
 	}
 
+	if os.Getenv("TF_COSIGN_DISABLE") != "" {
+		return digest.String(), errors.New("TF_COSIGN_DISABLE is set, skipping signing"), nil
+	}
 	if !r.popts.oidc.Enabled(ctx) {
-		return digest.String(), errors.New("no ambient credentials are available to sign with, skipping signing."), nil
+		return digest.String(), errors.New("no ambient credentials are available to sign with, skipping signing"), nil
 	}
 
 	sv, err := r.popts.signerVerifier(data.FulcioURL.ValueString())


### PR DESCRIPTION
This change allows us to disable signing explicitly by settings `TF_COSIGN_DISABLE` to any value.