### PR TITLE
Add support for multiple attestations at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,22 @@ resource "cosign_sign" "example" {
 
 resource "cosign_attest" "example" {
   image          = cosign_sign.example.signed_ref
-  predicate_type = "https://example.com/my/predicate/type"
-  predicate      = jsonencode({
-    // Your claim here!
-  })
+
+  predicates {
+    type = "https://example.com/my/predicate/type"
+    json = jsonencode({
+      // Your claim here!
+    })
+  }
+
+  // Inlining e.g. huge SBOMs will slow down terraform a lot, so reference a file.
+  predicates {
+    type = "https://example.com/my/predicate/too-big-for-terraform.tfstate"
+    file = {
+      path   = "/tmp/giant-file.json"
+      sha256 = "74af7407b59f9021f76a6f9ee66149c5df1ef6442617a805a7860ce18074158d"
+    }
+  }
 }
 
 # Reference cosign_attest.example.attested_ref to ensure we wait for all of the

--- a/docs/resources/attest.md
+++ b/docs/resources/attest.md
@@ -18,13 +18,14 @@ This attests the provided image digest with cosign.
 ### Required
 
 - `image` (String) The digest of the container image to attest.
-- `predicate_type` (String) The in-toto predicate type of the claim being attested.
 
 ### Optional
 
 - `fulcio_url` (String) Address of sigstore PKI server (default https://fulcio.sigstore.dev).
-- `predicate` (String) The JSON body of the in-toto predicate's claim.
-- `predicate_file` (Block List) The path and sha256 hex of the predicate to attest. (see [below for nested schema](#nestedblock--predicate_file))
+- `predicate` (String, Deprecated) The JSON body of the in-toto predicate's claim.
+- `predicate_file` (Block List, Deprecated) The path and sha256 hex of the predicate to attest. (see [below for nested schema](#nestedblock--predicate_file))
+- `predicate_type` (String, Deprecated) The in-toto predicate type of the claim being attested.
+- `predicates` (Block List) The path and sha256 hex of the predicate to attest. (see [below for nested schema](#nestedblock--predicates))
 - `rekor_url` (String) Address of rekor transparency log server (default https://rekor.sigstore.dev).
 
 ### Read-Only
@@ -34,6 +35,27 @@ This attests the provided image digest with cosign.
 
 <a id="nestedblock--predicate_file"></a>
 ### Nested Schema for `predicate_file`
+
+Optional:
+
+- `path` (String) The path to a file containing the predicate to attest.
+- `sha256` (String) The sha256 hex hash of the predicate body.
+
+
+<a id="nestedblock--predicates"></a>
+### Nested Schema for `predicates`
+
+Required:
+
+- `type` (String) The in-toto predicate type of the claim being attested.
+
+Optional:
+
+- `file` (Block List) The path and sha256 hex of the predicate to attest. (see [below for nested schema](#nestedblock--predicates--file))
+- `json` (String) The JSON body of the in-toto predicate's claim.
+
+<a id="nestedblock--predicates--file"></a>
+### Nested Schema for `predicates.file`
 
 Optional:
 

--- a/internal/provider/resource_attest_test.go
+++ b/internal/provider/resource_attest_test.go
@@ -207,3 +207,155 @@ data "cosign_verify" "bar" {
 		},
 	})
 }
+
+func TestAccResourceCosignAttests(t *testing.T) {
+	if _, ok := os.LookupEnv("ACTIONS_ID_TOKEN_REQUEST_URL"); !ok {
+		t.Skip("Unable to keylessly attest without an actions token")
+	}
+
+	repo, cleanup := ocitesting.SetupRepository(t, "test")
+	defer cleanup()
+
+	// Push two images by digest.
+	img1, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dig1, err := img1.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref1 := repo.Digest(dig1.String())
+	if err := remote.Write(ref1, img1); err != nil {
+		t.Fatal(err)
+	}
+
+	img2, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dig2, err := img2.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref2 := repo.Digest(dig2.String())
+	if err := remote.Write(ref2, img2); err != nil {
+		t.Fatal(err)
+	}
+
+	url := "https://example.com/" + uuid.New().String()
+	url2 := "https://example.com/" + uuid.New().String()
+
+	value := uuid.New().String()
+
+	tmp, err := os.CreateTemp("", "cosign-attest-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := fmt.Sprintf(`{"foo": %q}`, value)
+	if _, err := tmp.WriteString(contents); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	rawHash := sha256.Sum256([]byte(contents))
+	hash := hex.EncodeToString(rawHash[:])
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Attest and verify the first image.
+			{
+				Config: fmt.Sprintf(`
+resource "cosign_attest" "foo" {
+  image          = %q
+  predicates {
+    type = %q
+    json = jsonencode({
+      foo = %q
+    })
+  }
+
+  predicates {
+    type = %q
+    file {
+      path   = %q
+      sha256 = %q
+    }
+  }
+}
+
+data "cosign_verify" "bar" {
+  image  = cosign_attest.foo.attested_ref
+  policy = jsonencode({
+    apiVersion = "policy.sigstore.dev/v1beta1"
+    kind       = "ClusterImagePolicy"
+    metadata = {
+      name = "attested-it"
+    }
+    spec = {
+      images = [{
+        glob = %q
+      }]
+      authorities = [{
+        keyless = {
+          url = "https://fulcio.sigstore.dev"
+          identities = [{
+            issuer  = "https://token.actions.githubusercontent.com"
+            subject = "https://github.com/chainguard-dev/terraform-provider-cosign/.github/workflows/test.yml@refs/heads/main"
+          }]
+        }
+        attestations = [{
+          name = "must-have-attestation"
+          predicateType = %q
+          policy = {
+            type = "cue"
+            // When we do things in this style, we can use file("foo.cue") too!
+            data = <<EOF
+              predicateType: %q
+              predicate: {
+                foo: string
+                // Uncommenting this leads to a failure.
+                // foo: "bar"
+                foo: %q
+              }
+            EOF
+          }
+        },{
+          name = "must-have-attestation"
+          predicateType = %q
+          policy = {
+            type = "cue"
+            // When we do things in this style, we can use file("foo.cue") too!
+            data = <<EOF
+              predicateType: %q
+              predicate: {
+                foo: string
+                // Uncommenting this leads to a failure.
+                // foo: "bar"
+                foo: %q
+              }
+            EOF
+          }
+        }]
+        ctlog = {
+          url = "https://rekor.sigstore.dev"
+        }
+      }]
+    }
+  })
+}
+`, ref1, url, value, url2, tmp.Name(), hash, ref1, url, url, value, url2, url2, value),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"cosign_attest.foo", "image", regexp.MustCompile("^"+ref1.String())),
+					resource.TestMatchResourceAttr(
+						"cosign_attest.foo", "attested_ref", regexp.MustCompile("^"+ref1.String())),
+					// Check that it got attested!
+					resource.TestMatchResourceAttr(
+						"data.cosign_verify.bar", "verified_ref", regexp.MustCompile("^"+ref1.String())),
+				),
+			},
+		},
+	})
+}

--- a/internal/secant/attest.go
+++ b/internal/secant/attest.go
@@ -12,7 +12,6 @@ import (
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant/models/intoto"
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant/tlog"
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant/types"
-	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -60,106 +59,112 @@ func NewStatement(digest name.Digest, predicate io.Reader, ptype string) (*types
 
 // Attest is roughly equivalent to cosign attest.
 // The only real implementation of types.CosignerSignerVerifier is fulcio.SignerVerifier.
-func Attest(ctx context.Context, statement *types.Statement, sv types.CosignerSignerVerifier, rekorClient *client.Rekor, ropt []remote.Option) error {
-	pae := dsse.PAE(ctypes.IntotoPayloadType, statement.Payload)
-	signed, err := sv.SignMessage(bytes.NewReader(pae), options.WithContext(ctx))
-	if err != nil {
-		return fmt.Errorf("signing pae: %w", err)
-	}
-
-	env := dsse.Envelope{
-		PayloadType: ctypes.IntotoPayloadType,
-		Payload:     base64.StdEncoding.EncodeToString(statement.Payload),
-		Signatures: []dsse.Signature{
-			{
-				Sig: base64.StdEncoding.EncodeToString(signed),
-			},
-		},
-	}
-
-	envelope, err := json.Marshal(env)
-	if err != nil {
-		return fmt.Errorf("marshaling envelope: %w", err)
-	}
-
-	// Use the inner Cosigner to safely generate a valid sig, then graft its values on our attestation.
-	sig, err := sv.Cosign(ctx, bytes.NewReader(envelope))
-	if err != nil {
-		return fmt.Errorf("signing envelope: %w", err)
-	}
-
-	cert, err := sig.Cert()
-	if err != nil {
-		return err
-	}
-
-	rawCert, err := cryptoutils.MarshalCertificateToPEM(cert)
-	if err != nil {
-		return err
-	}
-
-	chain, err := sig.Chain()
-	if err != nil {
-		return err
-	}
-
-	rawChain, err := cryptoutils.MarshalCertificatesToPEM(chain)
-	if err != nil {
-		return fmt.Errorf("marshaling chain: %w", err)
-	}
-
-	e, err := intoto.Entry(ctx, envelope, rawCert)
-	if err != nil {
-		return fmt.Errorf("creating intoto entry: %w", err)
-	}
-
-	logs.Debug.Printf("debug envelope:\n%s", envelope)
-	logs.Debug.Printf("debug rawCert:\n%s", rawCert)
-
-	entry, err := tlog.Upload(ctx, rekorClient, e)
-	if err != nil {
-		return fmt.Errorf("uploading to rekor: %w", err)
-	}
-
-	bundle := cbundle.EntryToBundle(entry)
-
-	predicateType, err := parsePredicateType(statement.Type)
-	if err != nil {
-		return err
-	}
-
-	opts := []static.Option{
-		static.WithCertChain(rawCert, rawChain),
-		static.WithBundle(bundle),
-		static.WithLayerMediaType(ctypes.DssePayloadType),
-		static.WithAnnotations(map[string]string{
-			"predicateType": predicateType,
-		}),
-	}
-
-	att, err := static.NewAttestation(envelope, opts...)
-	if err != nil {
-		return err
-	}
+func Attest(ctx context.Context, statements []*types.Statement, sv types.CosignerSignerVerifier, rekorClient *client.Rekor, ropt []remote.Option) error {
+	digest := statements[0].Digest
 
 	// We don't actually need to access the remote entity to attach things to it
 	// so we use a placeholder here.
-	se := ociremote.SignedUnknown(statement.Digest)
+	se := ociremote.SignedUnknown(digest)
 
-	signOpts := []mutate.SignOption{
-		mutate.WithDupeDetector(cremote.NewDupeDetector(sv)),
-		mutate.WithReplaceOp(cremote.NewReplaceOp(predicateType)),
-	}
+	for _, statement := range statements {
+		// Make sure these statements are all for the same subject.
+		if digest != statement.Digest {
+			return fmt.Errorf("mismatched attestations: %s != %s", digest.String(), statement.Digest.String())
+		}
 
-	// Attach the attestation to the entity.
-	se, err = mutate.AttachAttestationToEntity(se, att, signOpts...)
-	if err != nil {
-		return err
+		pae := dsse.PAE(ctypes.IntotoPayloadType, statement.Payload)
+		signed, err := sv.SignMessage(bytes.NewReader(pae), options.WithContext(ctx))
+		if err != nil {
+			return fmt.Errorf("signing pae: %w", err)
+		}
+
+		env := dsse.Envelope{
+			PayloadType: ctypes.IntotoPayloadType,
+			Payload:     base64.StdEncoding.EncodeToString(statement.Payload),
+			Signatures: []dsse.Signature{
+				{
+					Sig: base64.StdEncoding.EncodeToString(signed),
+				},
+			},
+		}
+
+		envelope, err := json.Marshal(env)
+		if err != nil {
+			return fmt.Errorf("marshaling envelope: %w", err)
+		}
+
+		// Use the inner Cosigner to safely generate a valid sig, then graft its values on our attestation.
+		sig, err := sv.Cosign(ctx, bytes.NewReader(envelope))
+		if err != nil {
+			return fmt.Errorf("signing envelope: %w", err)
+		}
+
+		cert, err := sig.Cert()
+		if err != nil {
+			return err
+		}
+
+		rawCert, err := cryptoutils.MarshalCertificateToPEM(cert)
+		if err != nil {
+			return err
+		}
+
+		chain, err := sig.Chain()
+		if err != nil {
+			return err
+		}
+
+		rawChain, err := cryptoutils.MarshalCertificatesToPEM(chain)
+		if err != nil {
+			return fmt.Errorf("marshaling chain: %w", err)
+		}
+
+		e, err := intoto.Entry(ctx, envelope, rawCert)
+		if err != nil {
+			return fmt.Errorf("creating intoto entry: %w", err)
+		}
+
+		entry, err := tlog.Upload(ctx, rekorClient, e)
+		if err != nil {
+			return fmt.Errorf("uploading to rekor: %w", err)
+		}
+
+		bundle := cbundle.EntryToBundle(entry)
+
+		predicateType, err := parsePredicateType(statement.Type)
+		if err != nil {
+			return err
+		}
+
+		opts := []static.Option{
+			static.WithCertChain(rawCert, rawChain),
+			static.WithBundle(bundle),
+			static.WithLayerMediaType(ctypes.DssePayloadType),
+			static.WithAnnotations(map[string]string{
+				"predicateType": predicateType,
+			}),
+		}
+
+		att, err := static.NewAttestation(envelope, opts...)
+		if err != nil {
+			return err
+		}
+
+		signOpts := []mutate.SignOption{
+			mutate.WithDupeDetector(cremote.NewDupeDetector(sv)),
+			mutate.WithReplaceOp(cremote.NewReplaceOp(predicateType)),
+		}
+
+		// Attach the attestation to the entity.
+		se, err = mutate.AttachAttestationToEntity(se, att, signOpts...)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Publish the attestations associated with this entity
 	ropts := []ociremote.Option{ociremote.WithRemoteOptions(ropt...)}
-	return ociremote.WriteAttestations(statement.Digest.Repository, se, ropts...)
+	return ociremote.WriteAttestations(digest.Repository, se, ropts...)
 }
 
 var predicateTypeMap = map[string]string{


### PR DESCRIPTION
We should bikeshed exact format and names here.

Combined with: https://github.com/chainguard-dev/terraform-publisher-apko/pull/18

I instrumented `terraform` output how long each `WriteState` invocation took, then ran a few things locally before and after.

```
terraform apply -auto-approve -target=module.go
```

With just a single module, things look not that different...

Total `WriteState` latency: 5.7s -> 4.185s (~27% drop)

Number of `WriteState` calls: 344 ->  260 (~24% drop)

But if we pull in some more modules:

```
terraform apply -auto-approve -target=module.go -target=module.dotnet -target=module.python -target=module.python-fips -target=module.go-fips
```

Total `WriteState` latency: 50s -> 33s (~34% drop)

Number of `WriteState` calls: 1078 ->  796 (~26% drop)

If we look plot each point (milliseconds), we see something like this:

![image](https://github.com/chainguard-dev/terraform-provider-cosign/assets/17863526/349a7e87-bed2-4a1e-af41-d3879c231329)

The latency for each `WriteState` grows ~linearly with the the size of the `terraform.tfstate` file, which is proportional to the number of resources, so the overall latency will grow quadratically.

Terraform also allocates two new buffer that end up growing to be the size of the `terraform.tfstate` file (and the previous file), so this also starts to cause a lot of GC pressure as the size increases.