### PR TITLE
Add k8s filesystem OIDC token provider.

### DIFF
--- a/internal/provider/oidc.go
+++ b/internal/provider/oidc.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 
-	_ "github.com/chainguard-dev/terraform-provider-cosign/internal/provider/interactive"
 	"github.com/sigstore/cosign/v2/pkg/providers"
+
+	_ "github.com/chainguard-dev/terraform-provider-cosign/internal/provider/interactive"
+	_ "github.com/sigstore/cosign/v2/pkg/providers/filesystem"
 	_ "github.com/sigstore/cosign/v2/pkg/providers/github"
 )
 


### PR DESCRIPTION
I want to try and get this running inside of Tekton, which needs the k8s OIDC token provider to properly sign images.