### PR TITLE
minor improvements to available creds datasource

### DIFF
--- a/internal/provider/data_source_available_credentials.go
+++ b/internal/provider/data_source_available_credentials.go
@@ -103,7 +103,7 @@ func (d *AvailableDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	var available []string
+	available := []string{}
 	if interactiveAvailable() {
 		available = append(available, "interactive")
 	}

--- a/internal/secant/fulcio/fulcio.go
+++ b/internal/secant/fulcio/fulcio.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant/types"
-	"github.com/google/certificate-transparency-go/x509"
 
+	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/oci"

--- a/internal/secant/rekor/rekor.go
+++ b/internal/secant/rekor/rekor.go
@@ -17,11 +17,14 @@ package rekor
 import (
 	"context"
 	"crypto/sha256"
+	"fmt"
 	"io"
+	"time"
 
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant/models/rekord"
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant/tlog"
 	"github.com/chainguard-dev/terraform-provider-cosign/internal/secant/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	cbundle "github.com/sigstore/cosign/v2/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
@@ -77,6 +80,12 @@ func (rs *signerWrapper) Cosign(ctx context.Context, payload io.Reader) (oci.Sig
 	if err != nil {
 		return nil, err
 	}
+
+	tflog.Info(ctx, "uploaded entry", map[string]interface{}{
+		"uuid":           *entry.LogID,
+		"integratedTime": time.Unix(*entry.IntegratedTime, 0).Format(time.RFC3339),
+		"logIndex":       fmt.Sprintf("%d", *entry.LogIndex),
+	})
 
 	bundle, err := cbundle.EntryToBundle(entry), nil
 	if err != nil {

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,18 @@
 terraform {
   required_providers {
     cosign = {
-        source = "chainguard-dev/cosign"
+      source = "chainguard-dev/cosign"
     }
   }
+
+  backend "inmem" {}
+
 }
 
+data "cosign_available_credentials" "available" {}
+
 resource "cosign_sign" "image" {
-  image = "us-docker.pkg.dev/wlynch-chainguard/public/ko-gcloud@sha256:d882f1b1ba89f712f00d955c7268d66f89774f79e922258cd6194ae18e8ac7ce"
+  for_each      = data.cosign_available_credentials.available.available
+  oidc_provider = each.key
+  image         = "ttl.sh/jason@sha256:13b7e62e8df80264dbb747995705a986aa530415763a6c58f84a3ca8af9a5bcd"
 }


### PR DESCRIPTION
- `tflog` the Rekor entry(s) that get uploaded
- don't return a `nil` set, which can't be passed to `for_each` -- instead, return an empty set
- rearrange an importpath to appease linter
- update the example `main.tf` to help test usage