### PR TITLE
Don't rely on the cache in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache: false
 
       # This is provisioned here: https://github.com/chainguard-dev/secrets/blob/main/terraform-provider-cosign.tf
       - uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2


### PR DESCRIPTION
This disables reliance on the cache in release workflows.