### PR TITLE
--rm-dist is deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '1.3.*'
-          - '1.2.*'
-          - '1.1.*'
-          - '1.0.*'
+        - '1.8.*'
+        - '1.9.*'
+        - '1.10.*'
 
     permissions:
       contents: read


### PR DESCRIPTION
https://github.com/chainguard-dev/terraform-provider-cosign/actions/runs/12658049868/job/35274112772

```
  ⨯ command failed                                   error=unknown flag: --rm-dist
```