### PR TITLE
Update secant Attest() and Sign() conflict handling to accept an interface instead of a string

### DIFF
--- a/internal/provider/conflict.go
+++ b/internal/provider/conflict.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant"
+)
+
+type conflictOp interface {
+	secant.AttestConflictOp
+	secant.SignConflictOp
+}
+
+func toConflictOp(conflict string) (conflictOp, error) {
+	switch conflict {
+	case "REPLACE":
+		return secant.Replace, nil
+	case "APPEND":
+		return secant.Append, nil
+	case "SKIPSAME":
+		return secant.SkipSame, nil
+	default:
+		return nil, fmt.Errorf("invalid conflict %q", conflict)
+	}
+}

--- a/internal/provider/resource_attest.go
+++ b/internal/provider/resource_attest.go
@@ -348,7 +348,7 @@ func (r *AttestResource) doAttest(ctx context.Context, arm *AttestResourceModel,
 	ctx, cancel := context.WithTimeout(ctx, options.DefaultTimeout)
 	defer cancel()
 
-	op, err := toAttestConflictOp(arm)
+	op, err := toConflictOp(arm.Conflict.ValueString())
 	if err != nil {
 		return "", nil, err
 	}
@@ -358,19 +358,6 @@ func (r *AttestResource) doAttest(ctx context.Context, arm *AttestResourceModel,
 	}
 
 	return digest.String(), nil, nil
-}
-
-func toAttestConflictOp(arm *AttestResourceModel) (secant.AttestConflictOp, error) {
-	switch arm.Conflict.ValueString() {
-	case "REPLACE":
-		return &secant.ReplaceOp{SkipSame: false}, nil
-	case "APPEND":
-		return &secant.AppendOp{}, nil
-	case "SKIPSAME":
-		return &secant.ReplaceOp{SkipSame: true}, nil
-	default:
-		return nil, fmt.Errorf("invalid conflict %q", arm.Conflict.ValueString())
-	}
 }
 
 func (r *AttestResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/resource_attest_test.go
+++ b/internal/provider/resource_attest_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-
 	"strings"
 	"testing"
 

--- a/internal/provider/resource_sign.go
+++ b/internal/provider/resource_sign.go
@@ -143,7 +143,11 @@ func (r *SignResource) doSign(ctx context.Context, data *SignResourceModel) (str
 	// TODO: This should probably be configurable?
 	var annotations map[string]interface{} = nil
 
-	if err := secant.Sign(ctx, data.Conflict.ValueString(), annotations, sv, rekorClient, []name.Digest{digest}, r.popts.ropts); err != nil {
+	conflictOp, err := toConflictOp(data.Conflict.ValueString())
+	if err != nil {
+		return "", nil, err
+	}
+	if err := secant.Sign(ctx, conflictOp, annotations, sv, rekorClient, []name.Digest{digest}, r.popts.ropts); err != nil {
 		return "", nil, fmt.Errorf("unable to sign image %q: %w", digest.String(), err)
 	}
 	return digest.String(), nil, nil

--- a/pkg/private/secant/at_test.go
+++ b/pkg/private/secant/at_test.go
@@ -81,7 +81,11 @@ func TestNewStatements(t *testing.T) {
 		want:       0,
 	}} {
 		t.Run(fmt.Sprintf("newStatements[%d]", i), func(t *testing.T) {
-			statements, err := newStatements(tc.statements, tc.sigments, tc.conflict)
+			op, err := newAttestConflictOp[*sigment](tc.conflict)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, statements, err := op.mergeAttestations(tc.sigments, tc.statements)
 			if err != nil {
 				if !tc.err {
 					t.Error(err)

--- a/pkg/private/secant/attest.go
+++ b/pkg/private/secant/attest.go
@@ -211,17 +211,8 @@ func parsePredicateType(t string) (string, error) {
 	return uri, nil
 }
 
-// Append adds signatures onto an image without modifying the existing signatures.
-type AppendOp struct{}
-
 func (a *AppendOp) MergeAttestations(sigs []oci.Signature, stmts []*types.Statement) ([]oci.Signature, []*types.Statement, error) {
 	return sigs, stmts, nil
-}
-
-// Replace replaces signatures on the image.
-type ReplaceOp struct {
-	// SkipSame controls whether equivalent signatures are written onto the image (when false) or skipped (when true)
-	SkipSame bool
 }
 
 // Returns only the statements that we actually need to write.

--- a/pkg/private/secant/conflict.go
+++ b/pkg/private/secant/conflict.go
@@ -93,11 +93,7 @@ func (r *replaceSignedEntityAttestations) Attestations() (oci.Signatures, error)
 	if err != nil {
 		return nil, err
 	}
-	replaced, err := mutate.ReplaceSignatures(&replaceOCISignatures{Signatures: atts, sigs: r.atts})
-	if err != nil {
-		return nil, err
-	}
-	return replaced, err
+	return mutate.ReplaceSignatures(&replaceOCISignatures{Signatures: atts, sigs: r.atts})
 }
 
 type replaceSignedEntitySignatures struct {
@@ -110,9 +106,5 @@ func (r *replaceSignedEntitySignatures) Signatures() (oci.Signatures, error) {
 	if err != nil {
 		return nil, err
 	}
-	replaced, err := mutate.ReplaceSignatures(&replaceOCISignatures{Signatures: atts, sigs: r.sigs})
-	if err != nil {
-		return nil, err
-	}
-	return replaced, err
+	return mutate.ReplaceSignatures(&replaceOCISignatures{Signatures: atts, sigs: r.sigs})
 }

--- a/pkg/private/secant/replace.go
+++ b/pkg/private/secant/replace.go
@@ -18,7 +18,7 @@ const (
 	Append = "APPEND"
 )
 
-func getPredicateType(s sigsubset) (string, error) {
+func getPredicateType(s oci.Signature) (string, error) {
 	anns, err := s.Annotations()
 	if err != nil {
 		return "", fmt.Errorf("could not get annotations: %w", err)


### PR DESCRIPTION
Update `secant.Attest()` and `secant.Sign()` to accept an interface rather than a "conflict" string. There aren't any changes to the actual terraform interface or behavior in this PR.

This will make it easier to encode more sophisticated behavior in the conflict handling logic, such as handling signatures from multiple identities or adding a TTL with `SKIPSAME`.