### PR TITLE
Change Rekor rate limiting to be context-aware

### DIFF
--- a/pkg/private/secant/sign.go
+++ b/pkg/private/secant/sign.go
@@ -17,11 +17,16 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/oci/walk"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	sigPayload "github.com/sigstore/sigstore/pkg/signature/payload"
+	"golang.org/x/time/rate"
 )
 
 // SignEntity is roughly equivalent to cosign sign.
 // It operates on the provided oci.SignedEntity without interacting with the registry.
-func SignEntity(ctx context.Context, se oci.SignedEntity, subject name.Digest, conflict string, annotations map[string]interface{}, cs types.Cosigner, rekorClient *client.Rekor) (oci.SignedEntity, error) {
+func SignEntity(ctx context.Context, se oci.SignedEntity, subject name.Digest, conflict string, annotations map[string]interface{}, cs types.Cosigner, rekorClient *client.Rekor, opts ...SignOption) (oci.SignedEntity, error) {
+	o, err := makeSignOptions(opts)
+	if err != nil {
+		return nil, fmt.Errorf("initializing sign options: %w", err)
+	}
 	// Get the digest for this entity in our walk.
 	d, err := se.(interface{ Digest() (v1.Hash, error) }).Digest()
 	if err != nil {
@@ -66,6 +71,11 @@ func SignEntity(ctx context.Context, se oci.SignedEntity, subject name.Digest, c
 		return nil, fmt.Errorf("unhandled conflict type: %q", conflict)
 	}
 
+	if o.rekorLimiter != nil {
+		if err := o.rekorLimiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("waiting for rekor rate limiter: %w", err)
+		}
+	}
 	ociSig, err = rekor.AttachHashedRekord(ctx, rekorClient, ociSig)
 	if err != nil {
 		return nil, fmt.Errorf("attaching rekor bundle: %w", err)
@@ -76,11 +86,11 @@ func SignEntity(ctx context.Context, se oci.SignedEntity, subject name.Digest, c
 }
 
 // Sign is roughly equivalent to cosign sign.
-func Sign(ctx context.Context, conflict string, annotations map[string]interface{}, sv types.CosignerVerifier, rekorClient *client.Rekor, imgs []name.Digest, ropt []remote.Option) error {
-	opts := []ociremote.Option{ociremote.WithRemoteOptions(ropt...)}
+func Sign(ctx context.Context, conflict string, annotations map[string]interface{}, sv types.CosignerVerifier, rekorClient *client.Rekor, imgs []name.Digest, ropt []remote.Option, opts ...SignOption) error {
+	rOpts := []ociremote.Option{ociremote.WithRemoteOptions(ropt...)}
 
 	for _, ref := range imgs {
-		se, err := ociremote.SignedEntity(ref, opts...)
+		se, err := ociremote.SignedEntity(ref, rOpts...)
 		if err != nil {
 			return fmt.Errorf("accessing entity: %w", err)
 		}
@@ -92,12 +102,12 @@ func Sign(ctx context.Context, conflict string, annotations map[string]interface
 				return fmt.Errorf("computing digest: %w", err)
 			}
 			digest := ref.Context().Digest(d.String())
-			newSE, err := SignEntity(ctx, se, digest, conflict, annotations, sv, rekorClient)
+			newSE, err := SignEntity(ctx, se, digest, conflict, annotations, sv, rekorClient, opts...)
 			if err != nil {
 				return fmt.Errorf("signing digest: %w", err)
 			}
 			// Publish the signatures associated with this entity
-			return ociremote.WriteSignatures(digest.Repository, newSE, opts...)
+			return ociremote.WriteSignatures(digest.Repository, newSE, rOpts...)
 		}); err != nil {
 			return fmt.Errorf("recursively signing: %w", err)
 		}
@@ -174,4 +184,30 @@ func (r skipSameSignatures) Find(signatures oci.Signatures, o oci.Signature) (oc
 	}
 
 	return nil, nil
+}
+
+type signOptions struct {
+	rekorLimiter *rate.Limiter
+}
+
+type SignOption (func(*signOptions) error)
+
+func makeSignOptions(opts []SignOption) (*signOptions, error) {
+	o := &signOptions{
+		rekorLimiter: defaultRekorLimiter,
+	}
+	for _, opt := range opts {
+		if err := opt(o); err != nil {
+			return nil, err
+		}
+	}
+	return o, nil
+}
+
+// WithSignRekorLimiter rate limits calls to Rekor
+func WithSignRekorLimiter(limiter *rate.Limiter) AttestOption {
+	return func(o *attestOptions) error {
+		o.rekorLimiter = limiter
+		return nil
+	}
 }


### PR DESCRIPTION
There are two aspects to this change:

1) We're now using a rate limiter that is aware of the context deadline + context cancellation

The prior implementation effectively just did a `Sleep()` to maintain the requested rate limit. This causes problems if the wait time falls outside of the context lifetime. The goroutine will wait, but it's not going to be able to do anything useful when it wakes up. This can easily cascade into a situation where all goroutines are waiting even after their context has been cancelled.

The rate limiter from `x/time/rate` is aware of the context and will immediately return an error rather than waiting past its deadline. It'll also cancel its "reservation" in the rate limiter if the context is cancelled for other reasons, possibly letting another goroutine proceed with a shorter wait. 

2) Move the rate limiter check into `SignEntity()/AttestEntity()`

The prior implementation applied rate limiting on each individual HTTP request going to Rekor. Now that the call to the rate limiter may fail, this means attesting 5 statements may succeed for the first 4 but fail for the last one. This wastes our calls to Rekor, since we won't actually end up using the result. We can avoid this type of partial failure by waiting up-front for the number of statements we need to sign/upload.