### PR TITLE
Change default conflict mode to "SKIPSAME"

### DIFF
--- a/internal/provider/resource_attest.go
+++ b/internal/provider/resource_attest.go
@@ -98,7 +98,7 @@ func (r *AttestResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Computed:            true,
 				Optional:            true,
 				Required:            false,
-				Default:             stringdefault.StaticString("REPLACE"),
+				Default:             stringdefault.StaticString("SKIPSAME"),
 				Validators:          []validator.String{ConflictValidator{}},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/resource_attest.go
+++ b/internal/provider/resource_attest.go
@@ -98,7 +98,7 @@ func (r *AttestResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Computed:            true,
 				Optional:            true,
 				Required:            false,
-				Default:             stringdefault.StaticString("APPEND"),
+				Default:             stringdefault.StaticString("REPLACE"),
 				Validators:          []validator.String{ConflictValidator{}},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/resource_sign.go
+++ b/internal/provider/resource_sign.go
@@ -72,7 +72,7 @@ func (r *SignResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Computed:            true,
 				Optional:            true,
 				Required:            false,
-				Default:             stringdefault.StaticString("REPLACE"),
+				Default:             stringdefault.StaticString("SKIPSAME"),
 				Validators:          []validator.String{ConflictValidator{}},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/resource_sign.go
+++ b/internal/provider/resource_sign.go
@@ -72,7 +72,7 @@ func (r *SignResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Computed:            true,
 				Optional:            true,
 				Required:            false,
-				Default:             stringdefault.StaticString("APPEND"),
+				Default:             stringdefault.StaticString("REPLACE"),
 				Validators:          []validator.String{ConflictValidator{}},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),


### PR DESCRIPTION
We've found the "APPEND" default to be almost always wrong and instead would've wanted attestations to be replaced. This changes the default conflict resolution mode to "SKIPSAME" to encode that.