### PR TITLE
chore(harden-runner): allow more endpoints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
           allowed-endpoints: >
             *.blob.core.windows.net:443
             *.githubapp.com:443
+            _pgpkey-http._tcp.keys.openpgp.org:443
             api.github.com:443
             cloudresourcemanager.googleapis.com:443
             dl.google.com:443
@@ -32,6 +33,7 @@ jobs:
             iamcredentials.googleapis.com:443
             keys.openpgp.org:11371
             keys.openpgp.org:443
+            metadata.google.internal:443
             objects.githubusercontent.com:443
             octo-sts.dev:443
             proxy.golang.org:443
@@ -92,7 +94,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         if: steps.check.outputs.need_release == 'yes'
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           cache: false
           check-latest: true
 


### PR DESCRIPTION
These showed up in the latest Release Workflow run.