### PR TITLE
feat: add configurable timeout for signing and attestation operations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ data "cosign_verify" "example" {
 ### Optional
 
 - `default_attestation_entry_type` (String) Default Rekor entry type to use for attestations. Valid values are 'intoto' (default) or 'dsse'.
+- `timeout` (String) Timeout for signing and attestation operations, as a Go duration string (e.g. '5m', '10m'). Defaults to '3m'.
 
 ## Sign
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -35,12 +35,14 @@ type Provider struct {
 // ProviderModel describes the provider data model.
 type ProviderModel struct {
 	DefaultAttestationEntryType types.String `tfsdk:"default_attestation_entry_type"`
+	Timeout                     types.String `tfsdk:"timeout"`
 }
 
 type ProviderOpts struct {
 	ropts                       []remote.Option
 	keychain                    authn.Keychain
 	defaultAttestationEntryType string
+	timeout                     time.Duration
 
 	oidc fulcio.OIDCProvider
 
@@ -109,6 +111,11 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 				Optional:            true,
 				Validators:          []validator.String{EntryTypeValidator{}},
 			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Timeout for signing and attestation operations, as a Go duration string (e.g. '5m', '10m'). Defaults to '3m'.",
+				Optional:            true,
+				Validators:          []validator.String{DurationValidator{}},
+			},
 		},
 	}
 }
@@ -143,11 +150,22 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		attestationEntryType = data.DefaultAttestationEntryType.ValueString()
 	}
 
+	timeout := 3 * time.Minute // same default as cosign CLI
+	if !data.Timeout.IsNull() && !data.Timeout.IsUnknown() {
+		d, err := time.ParseDuration(data.Timeout.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid timeout", "Unable to parse timeout duration: "+err.Error())
+			return
+		}
+		timeout = d
+	}
+
 	opts := &ProviderOpts{
 		ropts:                       ropts,
 		keychain:                    kc,
 		oidc:                        &oidcProvider{},
 		defaultAttestationEntryType: attestationEntryType,
+		timeout:                     timeout,
 		signers:                     map[string]*fulcio.SignerVerifier{},
 		rekorClients:                map[string]*client.Rekor{},
 	}
@@ -203,5 +221,27 @@ func (v EntryTypeValidator) ValidateString(ctx context.Context, req validator.St
 		return
 	default:
 		resp.Diagnostics.AddError("error validating default_attestation_entry_type", v.Description(ctx))
+	}
+}
+
+// DurationValidator is a string validator that checks that the string is a valid Go duration.
+type DurationValidator struct{}
+
+var _ validator.String = DurationValidator{}
+
+func (v DurationValidator) Description(context.Context) string {
+	return "value must be a valid Go duration string (e.g. '5m', '10m', '1h30m')"
+}
+
+func (v DurationValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v DurationValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if _, err := time.ParseDuration(req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddError("error validating timeout", err.Error())
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/fulcio/pkg/api"
 	"github.com/sigstore/rekor/pkg/generated/client"
 )
@@ -150,7 +151,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		attestationEntryType = data.DefaultAttestationEntryType.ValueString()
 	}
 
-	timeout := 3 * time.Minute // same default as cosign CLI
+	timeout := options.DefaultTimeout
 	if !data.Timeout.IsNull() && !data.Timeout.IsUnknown() {
 		d, err := time.ParseDuration(data.Timeout.ValueString())
 		if err != nil {

--- a/internal/provider/resource_attest.go
+++ b/internal/provider/resource_attest.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 )
 
 var (
@@ -367,7 +366,7 @@ func (r *AttestResource) doAttest(ctx context.Context, arm *AttestResourceModel,
 		return "", nil, fmt.Errorf("creating rekor client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, options.DefaultTimeout)
+	ctx, cancel := context.WithTimeout(ctx, r.popts.timeout)
 	defer cancel()
 
 	if err := secant.Attest(ctx, arm.Conflict.ValueString(), statements, sv, rekorClient, r.popts.withContext(ctx), secant.WithRekorEntryType(r.popts.defaultAttestationEntryType)); err != nil {

--- a/internal/provider/resource_sign.go
+++ b/internal/provider/resource_sign.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 )
 
 var (
@@ -137,7 +136,7 @@ func (r *SignResource) doSign(ctx context.Context, data *SignResourceModel) (str
 		return "", nil, fmt.Errorf("creating rekor client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, options.DefaultTimeout)
+	ctx, cancel := context.WithTimeout(ctx, r.popts.timeout)
 	defer cancel()
 
 	// TODO: This should probably be configurable?


### PR DESCRIPTION
## Summary
- Add a `timeout` provider attribute that accepts a Go duration string (e.g. `5m`, `10m`)
- Replace hardcoded `options.DefaultTimeout` in sign and attest resources with the configurable value
- Add `DurationValidator` for plan-time validation of the timeout string
- Default remains 3 minutes, matching the cosign CLI default

🤖 Generated with [Claude Code](https://claude.com/claude-code)