### PR TITLE
Raise attest predicate size limit from 10 MiB to 32 MiB

### DIFF
--- a/internal/provider/resource_attest.go
+++ b/internal/provider/resource_attest.go
@@ -333,7 +333,7 @@ func (r *AttestResource) doAttest(ctx context.Context, arm *AttestResourceModel,
 			// and upon receiving io.EOF checks that things match.  That said,
 			// it is going to end up in memory for the attestation anyway, so
 			// we just read it all in here.
-			const maxPredicateSize = 10 << 20 // 10 MB
+			const maxPredicateSize = 32 << 20 // 32 MB
 			fi, err := os.Stat(path)
 			if err != nil {
 				return "", nil, fmt.Errorf("stat predicate file %q: %w", path, err)


### PR DESCRIPTION
The 10 MiB cap added in #476 as an OOM guardrail is too tight for real SPDX SBOMs of image families with large transitive package sets, which routinely cross the limit and break image releases. 32 MiB keeps the guardrail but unblocks legitimate predicates without forcing every consumer to recompile.
