### PR TITLE
Retry CreateLogEntry on transient transport errors

### DIFF
--- a/pkg/private/secant/attest.go
+++ b/pkg/private/secant/attest.go
@@ -29,7 +29,6 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature/options"
-	"golang.org/x/time/rate"
 )
 
 var (
@@ -37,9 +36,11 @@ var (
 	intotoType = "intoto"
 )
 
-// RekorRateLimiter is used to throttle calls to Rekor when signing or attesting images in order to stay within the rate limits.
-// Defaults to a 5 QPS limit.
-var RekorRateLimiter = rate.NewLimiter(5.0, 50)
+// RekorRateLimiter is used to throttle calls to Rekor when signing or
+// attesting images in order to stay within the rate limits. Defaults to a
+// 5 QPS limit. Aliased to tlog.RekorRateLimiter so the same instance governs
+// both the pre-call waits here and the retry-time waits inside tlog.Upload.
+var RekorRateLimiter = tlog.RekorRateLimiter
 
 // NewStatement generates a statement for use in Attest.
 func NewStatement(digest name.Digest, predicate io.Reader, ptype string) (*types.Statement, error) {

--- a/pkg/private/secant/tlog/tlog.go
+++ b/pkg/private/secant/tlog/tlog.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
@@ -25,12 +26,27 @@ import (
 	"github.com/sigstore/sigstore/pkg/tuf"
 	"github.com/transparency-dev/merkle/proof"
 	"github.com/transparency-dev/merkle/rfc6962"
+	"golang.org/x/time/rate"
+)
+
+// RekorRateLimiter throttles all calls to Rekor (including retries from
+// createLogEntryWithRetry) to stay within rate limits. Defaults to 5 QPS with
+// a burst of 50.
+var RekorRateLimiter = rate.NewLimiter(5.0, 50)
+
+// Tuning knobs for retrying CreateLogEntry on transient errors. Exposed as
+// vars so tests can shrink the delays.
+var (
+	createLogEntryMaxAttempts    = 5
+	createLogEntryInitialBackoff = 500 * time.Millisecond
 )
 
 func Upload(ctx context.Context, rekorClient *client.Rekor, pe models.ProposedEntry) (*models.LogEntryAnon, error) {
 	params := entries.NewCreateLogEntryParamsWithContext(ctx)
 	params.SetProposedEntry(pe)
-	resp, err := rekorClient.Entries.CreateLogEntry(params)
+	resp, err := createLogEntryWithRetry(ctx, func() (*entries.CreateLogEntryCreated, error) {
+		return rekorClient.Entries.CreateLogEntry(params)
+	})
 	if err != nil {
 		// If the entry already exists, we get a specific error.
 		var existsErr *entries.CreateLogEntryConflict
@@ -55,6 +71,61 @@ func Upload(ctx context.Context, rekorClient *client.Rekor, pe models.ProposedEn
 		return &p, nil
 	}
 	return nil, errors.New("bad response from server")
+}
+
+// createLogEntryWithRetry retries create on transient transport errors. The
+// underlying retryablehttp client retries at the request level, but does not
+// catch errors that surface during response body decoding (notably HTTP/2
+// stream errors from Rekor). Between attempts the loop sleeps with
+// exponential backoff and then acquires a token from RekorRateLimiter, so
+// concurrent retries don't bypass the application-wide rate limit (the first
+// attempt's token is paid for by the caller in secant.Sign / secant.Attest,
+// before signing, so the Fulcio cert is fresh at upload time).
+func createLogEntryWithRetry(ctx context.Context, create func() (*entries.CreateLogEntryCreated, error)) (*entries.CreateLogEntryCreated, error) {
+	backoff := createLogEntryInitialBackoff
+	var lastErr error
+	for attempt := 1; attempt <= createLogEntryMaxAttempts; attempt++ {
+		resp, err := create()
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		if !isRetryableRekorError(err) || attempt == createLogEntryMaxAttempts {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+		if err := RekorRateLimiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("waiting for rekor rate limiter: %w", err)
+		}
+		backoff *= 2
+	}
+	return nil, lastErr
+}
+
+// isRetryableRekorError reports whether err from CreateLogEntry is worth
+// retrying here. Any typed API error — Conflict, BadRequest, or the catch-all
+// Default — is terminal at this layer: the underlying retryablehttp client
+// already retries 5xx and 429 at the request level. We only need to handle
+// untyped transport errors that surface during response body decoding
+// (notably HTTP/2 stream errors), which retryablehttp cannot see.
+func isRetryableRekorError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if _, ok := errors.AsType[*entries.CreateLogEntryConflict](err); ok {
+		return false
+	}
+	if _, ok := errors.AsType[*entries.CreateLogEntryBadRequest](err); ok {
+		return false
+	}
+	if _, ok := errors.AsType[*entries.CreateLogEntryDefault](err); ok {
+		return false
+	}
+	return true
 }
 
 func getTlogEntry(ctx context.Context, rekorClient *client.Rekor, entryUUID string) (*models.LogEntryAnon, error) {

--- a/pkg/private/secant/tlog/tlog.go
+++ b/pkg/private/secant/tlog/tlog.go
@@ -34,12 +34,10 @@ import (
 // a burst of 50.
 var RekorRateLimiter = rate.NewLimiter(5.0, 50)
 
-// Tuning knobs for retrying CreateLogEntry on transient errors. Exposed as
-// vars so tests can shrink the delays.
-var (
-	createLogEntryMaxAttempts    = 5
-	createLogEntryInitialBackoff = 500 * time.Millisecond
-)
+const createLogEntryMaxAttempts = 5
+
+// Exposed as a var so tests can shrink the delay.
+var createLogEntryInitialBackoff = 500 * time.Millisecond
 
 func Upload(ctx context.Context, rekorClient *client.Rekor, pe models.ProposedEntry) (*models.LogEntryAnon, error) {
 	params := entries.NewCreateLogEntryParamsWithContext(ctx)
@@ -83,13 +81,11 @@ func Upload(ctx context.Context, rekorClient *client.Rekor, pe models.ProposedEn
 // before signing, so the Fulcio cert is fresh at upload time).
 func createLogEntryWithRetry(ctx context.Context, create func() (*entries.CreateLogEntryCreated, error)) (*entries.CreateLogEntryCreated, error) {
 	backoff := createLogEntryInitialBackoff
-	var lastErr error
-	for attempt := 1; attempt <= createLogEntryMaxAttempts; attempt++ {
+	for attempt := 1; ; attempt++ {
 		resp, err := create()
 		if err == nil {
 			return resp, nil
 		}
-		lastErr = err
 		if !isRetryableRekorError(err) || attempt == createLogEntryMaxAttempts {
 			return nil, err
 		}
@@ -103,7 +99,6 @@ func createLogEntryWithRetry(ctx context.Context, create func() (*entries.Create
 		}
 		backoff *= 2
 	}
-	return nil, lastErr
 }
 
 // isRetryableRekorError reports whether err from CreateLogEntry is worth

--- a/pkg/private/secant/tlog/tlog_test.go
+++ b/pkg/private/secant/tlog/tlog_test.go
@@ -1,0 +1,120 @@
+package tlog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/sigstore/rekor/pkg/generated/client/entries"
+)
+
+func TestIsRetryableRekorError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"conflict", &entries.CreateLogEntryConflict{}, false},
+		{"badrequest", &entries.CreateLogEntryBadRequest{}, false},
+		{"default-4xx", entries.NewCreateLogEntryDefault(http.StatusForbidden), false},
+		{"default-5xx", entries.NewCreateLogEntryDefault(http.StatusBadGateway), false},
+		{"http2-stream-error", fmt.Errorf("stream error: stream ID 15; INTERNAL_ERROR; received from peer"), true},
+		{"wrapped-conflict", fmt.Errorf("outer: %w", &entries.CreateLogEntryConflict{}), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableRekorError(tc.err); got != tc.want {
+				t.Errorf("isRetryableRekorError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCreateLogEntryWithRetry_RetriesTransient(t *testing.T) {
+	defer shrinkRetryBackoff(t)()
+
+	var attempts int
+	transient := errors.New("stream error: stream ID 1; INTERNAL_ERROR; received from peer")
+
+	got, err := createLogEntryWithRetry(t.Context(), func() (*entries.CreateLogEntryCreated, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, transient
+		}
+		return &entries.CreateLogEntryCreated{}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestCreateLogEntryWithRetry_StopsOnConflict(t *testing.T) {
+	defer shrinkRetryBackoff(t)()
+
+	var attempts int
+	_, err := createLogEntryWithRetry(t.Context(), func() (*entries.CreateLogEntryCreated, error) {
+		attempts++
+		return nil, &entries.CreateLogEntryConflict{}
+	})
+	if _, ok := errors.AsType[*entries.CreateLogEntryConflict](err); !ok {
+		t.Fatalf("err = %v, want CreateLogEntryConflict", err)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (conflict should not retry)", attempts)
+	}
+}
+
+func TestCreateLogEntryWithRetry_ExhaustsAttempts(t *testing.T) {
+	defer shrinkRetryBackoff(t)()
+
+	var attempts int
+	transient := errors.New("stream error: INTERNAL_ERROR")
+	_, err := createLogEntryWithRetry(t.Context(), func() (*entries.CreateLogEntryCreated, error) {
+		attempts++
+		return nil, transient
+	})
+	if !errors.Is(err, transient) {
+		t.Fatalf("err = %v, want %v", err, transient)
+	}
+	if attempts != createLogEntryMaxAttempts {
+		t.Errorf("attempts = %d, want %d", attempts, createLogEntryMaxAttempts)
+	}
+}
+
+func TestCreateLogEntryWithRetry_AbortsOnContextCancel(t *testing.T) {
+	prev := createLogEntryInitialBackoff
+	createLogEntryInitialBackoff = time.Hour
+	defer func() { createLogEntryInitialBackoff = prev }()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var attempts int
+	_, err := createLogEntryWithRetry(ctx, func() (*entries.CreateLogEntryCreated, error) {
+		attempts++
+		cancel()
+		return nil, errors.New("stream error")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (should abort before second attempt)", attempts)
+	}
+}
+
+func shrinkRetryBackoff(t *testing.T) func() {
+	t.Helper()
+	prev := createLogEntryInitialBackoff
+	createLogEntryInitialBackoff = time.Millisecond
+	return func() { createLogEntryInitialBackoff = prev }
+}


### PR DESCRIPTION
Signing and attesting occasionally fails with an HTTP/2 stream error like "stream error: stream ID 15; INTERNAL_ERROR; received from peer", surfaced from rekorClient.Entries.CreateLogEntry. These errors fire during response body decoding, after the underlying retryablehttp client has already returned a response, so its request-level retry policy does not see them. Wrap the SDK call in a small bounded retry (up to 5 attempts, 500ms backoff doubling) for untyped errors only — typed Conflict/BadRequest/Default responses still terminate immediately, leaving retryablehttp in charge of status-based retries so the two layers do not amplify each other. A retried request that the server actually committed on the first try will come back as Conflict on the second, which the existing path already handles.
