### PR TITLE
Match bundle referrers via manifest when index omits annotations

### DIFF
--- a/pkg/private/secant/bundlesign.go
+++ b/pkg/private/secant/bundlesign.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +18,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	intotov1 "github.com/in-toto/attestation/go/v1"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
@@ -304,7 +307,7 @@ func resolveBundleConflict(digest name.Digest, predicateType string, newPayload 
 		return false, fmt.Errorf("unknown conflict mode: %q", conflict)
 	}
 
-	matching, err := matchingBundleReferrers(digest, predicateType, opts)
+	matching, err := matchingBundleReferrers(digest, predicateType, opts, ropt)
 	if err != nil {
 		return false, err
 	}
@@ -338,8 +341,8 @@ func resolveBundleConflict(digest name.Digest, predicateType string, newPayload 
 const bundleMediaTypePrefix = "application/vnd.dev.sigstore.bundle"
 
 // matchingBundleReferrers returns referrer descriptors for digest that are
-// sigstore bundles annotated with the given predicate type.
-func matchingBundleReferrers(digest name.Digest, predicateType string, opts []ociremote.Option) ([]v1.Descriptor, error) {
+// sigstore bundles carrying predicateType.
+func matchingBundleReferrers(digest name.Digest, predicateType string, opts []ociremote.Option, ropt []remote.Option) ([]v1.Descriptor, error) {
 	idx, err := ociremote.Referrers(digest, "", opts...)
 	if err != nil {
 		return nil, fmt.Errorf("listing referrers: %w", err)
@@ -347,14 +350,43 @@ func matchingBundleReferrers(digest name.Digest, predicateType string, opts []oc
 
 	var matching []v1.Descriptor
 	for _, m := range idx.Manifests {
-		if !strings.HasPrefix(m.ArtifactType, bundleMediaTypePrefix) {
-			continue
+		ok, err := bundleReferrerMatches(digest.Repository, m, predicateType, ropt)
+		if err != nil {
+			return nil, err
 		}
-		if m.Annotations[ociremote.BundlePredicateType] == predicateType {
+		if ok {
 			matching = append(matching, m)
 		}
 	}
 	return matching, nil
+}
+
+// bundleReferrerMatches reports whether referrer descriptor m is a sigstore
+// bundle carrying predicateType. When the index descriptor has both
+// artifactType and the annotation, that answers the question directly. But
+// annotations on referrers-index descriptors are only a spec SHOULD, and some
+// registries omit them (go-containerregistry does, both in its in-memory
+// registry and in its tag-schema fallback). When the annotation is missing it
+// fetches the referrer manifest, which always carries both. This keeps
+// matching correct on those registries instead of silently matching nothing.
+func bundleReferrerMatches(repo name.Repository, m v1.Descriptor, predicateType string, ropt []remote.Option) (bool, error) {
+	if strings.HasPrefix(m.ArtifactType, bundleMediaTypePrefix) {
+		if pt, ok := m.Annotations[ociremote.BundlePredicateType]; ok {
+			return pt == predicateType, nil
+		}
+	}
+	d, err := remote.Get(repo.Digest(m.Digest.String()), ropt...)
+	if err != nil {
+		// A 404 is a dangling fallback-index entry whose manifest was already
+		// deleted; ignore it rather than fail the whole prune.
+		var terr *transport.Error
+		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.HasPrefix(d.ArtifactType, bundleMediaTypePrefix) &&
+		d.Annotations[ociremote.BundlePredicateType] == predicateType, nil
 }
 
 // referrerDSSEPayload fetches the given referrer manifest, reads its first

--- a/pkg/private/secant/replace_referrers_test.go
+++ b/pkg/private/secant/replace_referrers_test.go
@@ -1,0 +1,131 @@
+package secant
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	dsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// bundleWithDSSEPayload builds a minimal serialized sigstore bundle wrapping a
+// DSSE envelope, enough for the SKIPSAME comparison to round-trip without a
+// real signer.
+func bundleWithDSSEPayload(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	b := &protobundle.Bundle{
+		MediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+		Content: &protobundle.Bundle_DsseEnvelope{
+			DsseEnvelope: &dsse.Envelope{
+				Payload:     payload,
+				PayloadType: "application/vnd.in-toto+json",
+			},
+		},
+	}
+	data, err := protojson.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshaling bundle: %v", err)
+	}
+	return data
+}
+
+// TestMatchingBundleReferrers_ManifestSourced exercises the
+// manifest-authoritative matching path. go-containerregistry's in-memory
+// registry serves the native referrers API but builds index descriptors
+// without the predicate-type annotation (a spec SHOULD); matching must fall
+// back to the referrer manifest and still find both bundles.
+func TestMatchingBundleReferrers_ManifestSourced(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject := pushImage(t, repo, img)
+
+	// Two successive status writes for the same predicate type. Distinct
+	// payloads give them distinct digests, mirroring two real referrers.
+	if err := writeBundleReferrer(subject, []byte(`{"bundle":"one"}`), testPredicateType, nil, nil); err != nil {
+		t.Fatalf("writing first referrer: %v", err)
+	}
+	if err := writeBundleReferrer(subject, []byte(`{"bundle":"two"}`), testPredicateType, nil, nil); err != nil {
+		t.Fatalf("writing second referrer: %v", err)
+	}
+
+	opts := []ociremote.Option{ociremote.WithRemoteOptions()}
+
+	matching, err := matchingBundleReferrers(subject, testPredicateType, opts, nil)
+	if err != nil {
+		t.Fatalf("matchingBundleReferrers: %v", err)
+	}
+	if len(matching) != 2 {
+		t.Fatalf("expected 2 matching referrers, got %d", len(matching))
+	}
+
+	// A different predicate type must match neither.
+	other, err := matchingBundleReferrers(subject, "https://example.com/other/v1", opts, nil)
+	if err != nil {
+		t.Fatalf("matchingBundleReferrers (other): %v", err)
+	}
+	if len(other) != 0 {
+		t.Fatalf("expected 0 matching referrers for unrelated predicate type, got %d", len(other))
+	}
+
+	// End-to-end REPLACE deletes every matching referrer (the caller then writes
+	// the single replacement). Afterwards nothing matches.
+	shouldWrite, err := resolveBundleConflict(subject, testPredicateType, []byte(`{"bundle":"three"}`), Replace, nil, opts)
+	if err != nil {
+		t.Fatalf("resolveBundleConflict(Replace): %v", err)
+	}
+	if !shouldWrite {
+		t.Fatal("expected REPLACE to request a write")
+	}
+
+	remaining, err := matchingBundleReferrers(subject, testPredicateType, opts, nil)
+	if err != nil {
+		t.Fatalf("matchingBundleReferrers after REPLACE: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("expected 0 matching referrers after REPLACE, got %d", len(remaining))
+	}
+}
+
+// TestResolveBundleConflict_SkipSame confirms SKIPSAME skips an identical
+// payload but writes a novel one, on a registry whose referrers index omits
+// annotations.
+func TestResolveBundleConflict_SkipSame(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject := pushImage(t, repo, img)
+
+	payload := []byte(`{"_type":"https://in-toto.io/Statement/v1"}`)
+	if err := writeBundleReferrer(subject, bundleWithDSSEPayload(t, payload), testPredicateType, nil, nil); err != nil {
+		t.Fatalf("writing referrer: %v", err)
+	}
+
+	opts := []ociremote.Option{ociremote.WithRemoteOptions()}
+
+	// Identical payload: SKIPSAME must skip the write.
+	shouldWrite, err := resolveBundleConflict(subject, testPredicateType, payload, SkipSame, nil, opts)
+	if err != nil {
+		t.Fatalf("resolveBundleConflict(SkipSame, identical): %v", err)
+	}
+	if shouldWrite {
+		t.Error("expected SKIPSAME to skip an identical payload")
+	}
+
+	// Different payload: SKIPSAME must request the write.
+	shouldWrite, err = resolveBundleConflict(subject, testPredicateType, []byte(`{"_type":"differs"}`), SkipSame, nil, opts)
+	if err != nil {
+		t.Fatalf("resolveBundleConflict(SkipSame, different): %v", err)
+	}
+	if !shouldWrite {
+		t.Error("expected SKIPSAME to write a novel payload")
+	}
+}


### PR DESCRIPTION
matchingBundleReferrers decided which existing referrers were "mine" by reading artifactType and the predicate-type annotation off the referrers index descriptor. Both are a spec SHOULD; many registries omit annotations from index descriptors (go-containerregistry does, in its in-memory registry and its tag-schema fallback). When the annotation is missing, matching found nothing, so REPLACE silently appended a duplicate referrer instead of replacing the prior one and SKIPSAME never recognized an identical payload.

Source the predicate type from the referrer manifest, which carries it authoritatively on every registry, keeping a fast path that trusts the index descriptor when it does populate both fields. A 404 on the manifest fetch is a dangling fallback-index entry and is skipped rather than failing the prune.