### PR TITLE
Prune fallback referrers index after REPLACE deletes

### DIFF
--- a/pkg/private/secant/bundlesign.go
+++ b/pkg/private/secant/bundlesign.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	ggcrtypes "github.com/google/go-containerregistry/pkg/v1/types"
 	intotov1 "github.com/in-toto/attestation/go/v1"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
@@ -325,13 +327,92 @@ func resolveBundleConflict(digest name.Digest, predicateType string, newPayload 
 		return true, nil
 	}
 
+	deleted := make([]v1.Hash, 0, len(matching))
 	for _, m := range matching {
 		ref := digest.Digest(m.Digest.String())
 		if err := remote.Delete(ref, ropt...); err != nil {
 			return false, fmt.Errorf("deleting referrer %s: %w", m.Digest, err)
 		}
+		deleted = append(deleted, m.Digest)
+	}
+
+	// On a registry without the native Referrers API, go-containerregistry
+	// tracks referrers in a client-maintained sha256-<subject> fallback-tag
+	// index. remote.Delete removes the referrer manifest but does NOT prune the
+	// descriptor from that index (a documented gap in go-containerregistry's
+	// Pusher.Delete). The next writeBundleReferrer would then read the stale
+	// index, append the new referrer, and re-PUT an index still referencing the
+	// just-deleted manifest, which a registry that validates index members
+	// rejects with MANIFEST_UNKNOWN. Prune the deleted descriptors now so the
+	// subsequent write commits a consistent index.
+	if err := pruneFallbackReferrers(digest, deleted, ropt); err != nil {
+		return false, fmt.Errorf("pruning fallback referrers for %q: %w", digest.String(), err)
 	}
 	return true, nil
+}
+
+// pruneFallbackReferrers removes the given descriptors from the sha256-<subject>
+// fallback-tag index, if one exists. It is a no-op on registries that implement
+// the native Referrers API (they compute referrers dynamically and maintain no
+// fallback tag, so the GET below 404s). The fallback tag layout mirrors
+// go-containerregistry's unexported fallbackTag: the subject digest with its
+// ":" replaced by "-", as a tag on the subject's repository.
+func pruneFallbackReferrers(subject name.Digest, deleted []v1.Hash, ropt []remote.Option) error {
+	if len(deleted) == 0 {
+		return nil
+	}
+
+	tag := subject.Context().Tag(strings.Replace(subject.DigestStr(), ":", "-", 1))
+	desc, err := remote.Get(tag, ropt...)
+	if err != nil {
+		if isReferrerNotFound(err) {
+			// No fallback index: native Referrers API, or nothing left to prune.
+			return nil
+		}
+		return fmt.Errorf("fetching fallback index %q: %w", tag.String(), err)
+	}
+
+	var im v1.IndexManifest
+	if err := json.Unmarshal(desc.Manifest, &im); err != nil {
+		return fmt.Errorf("parsing fallback index %q: %w", tag.String(), err)
+	}
+
+	drop := make(map[v1.Hash]struct{}, len(deleted))
+	for _, h := range deleted {
+		drop[h] = struct{}{}
+	}
+	kept := im.Manifests[:0]
+	changed := false
+	for _, m := range im.Manifests {
+		if _, ok := drop[m.Digest]; ok {
+			changed = true
+			continue
+		}
+		kept = append(kept, m)
+	}
+	if !changed {
+		return nil
+	}
+	im.Manifests = kept
+
+	if err := remote.Put(tag, &fallbackIndex{im: im}, ropt...); err != nil {
+		return fmt.Errorf("rewriting fallback index %q: %w", tag.String(), err)
+	}
+	return nil
+}
+
+// fallbackIndex serializes a pruned fallback-tag index for a manifest PUT,
+// mirroring go-containerregistry's unexported fallbackTaggable.
+type fallbackIndex struct {
+	im v1.IndexManifest
+}
+
+func (f *fallbackIndex) RawManifest() ([]byte, error)            { return json.Marshal(f.im) }
+func (f *fallbackIndex) MediaType() (ggcrtypes.MediaType, error) { return ggcrtypes.OCIImageIndex, nil }
+
+func isReferrerNotFound(err error) bool {
+	var terr *transport.Error
+	return errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound
 }
 
 // bundleMediaTypePrefix matches sigstore bundle media types across all
@@ -341,7 +422,13 @@ func resolveBundleConflict(digest name.Digest, predicateType string, newPayload 
 const bundleMediaTypePrefix = "application/vnd.dev.sigstore.bundle"
 
 // matchingBundleReferrers returns referrer descriptors for digest that are
-// sigstore bundles carrying predicateType.
+// sigstore bundles carrying predicateType. It trusts the referrers-index
+// descriptor when the registry populated both artifactType and the
+// predicateType annotation, and otherwise consults the referrer manifest, which
+// is authoritative on every registry. This keeps REPLACE/SKIPSAME correct on
+// registries that omit those fields from the referrers index — notably
+// go-containerregistry's tag-schema fallback, whose index descriptors carry an
+// artifactType but no annotations.
 func matchingBundleReferrers(digest name.Digest, predicateType string, opts []ociremote.Option, ropt []remote.Option) ([]v1.Descriptor, error) {
 	idx, err := ociremote.Referrers(digest, "", opts...)
 	if err != nil {
@@ -361,32 +448,49 @@ func matchingBundleReferrers(digest name.Digest, predicateType string, opts []oc
 	return matching, nil
 }
 
-// bundleReferrerMatches reports whether referrer descriptor m is a sigstore
-// bundle carrying predicateType. When the index descriptor has both
-// artifactType and the annotation, that answers the question directly. But
-// annotations on referrers-index descriptors are only a spec SHOULD, and some
-// registries omit them (go-containerregistry does, both in its in-memory
-// registry and in its tag-schema fallback). When the annotation is missing it
-// fetches the referrer manifest, which always carries both. This keeps
-// matching correct on those registries instead of silently matching nothing.
+// bundleReferrerMatches reports whether the referrer described by m is a
+// sigstore bundle carrying predicateType.
 func bundleReferrerMatches(repo name.Repository, m v1.Descriptor, predicateType string, ropt []remote.Option) (bool, error) {
+	// Fast path: the index descriptor already carries what we need (zot, GAR, …),
+	// so no per-referrer manifest fetch is required.
 	if strings.HasPrefix(m.ArtifactType, bundleMediaTypePrefix) {
 		if pt, ok := m.Annotations[ociremote.BundlePredicateType]; ok {
 			return pt == predicateType, nil
 		}
 	}
-	d, err := remote.Get(repo.Digest(m.Digest.String()), ropt...)
+
+	// Slow path: the registry dropped artifactType and/or annotations from the
+	// index, or reported the config descriptor's media type as the artifactType
+	// (the OCI referrers spec permits this, and cosign bundles use the empty-config
+	// media type, so a real bundle can surface here with a non-bundle
+	// artifactType). The referrer manifest is authoritative.
+	at, ann, err := referrerManifestInfo(repo, m.Digest, ropt)
 	if err != nil {
-		// A 404 is a dangling fallback-index entry whose manifest was already
-		// deleted; ignore it rather than fail the whole prune.
-		var terr *transport.Error
-		if errors.As(err, &terr) && terr.StatusCode == http.StatusNotFound {
+		if isReferrerNotFound(err) {
+			// Dangling fallback-index entry for an already-deleted referrer.
 			return false, nil
 		}
 		return false, err
 	}
-	return strings.HasPrefix(d.ArtifactType, bundleMediaTypePrefix) &&
-		d.Annotations[ociremote.BundlePredicateType] == predicateType, nil
+	return strings.HasPrefix(at, bundleMediaTypePrefix) &&
+		ann[ociremote.BundlePredicateType] == predicateType, nil
+}
+
+// referrerManifestInfo fetches a referrer manifest and returns its top-level
+// artifactType and annotations.
+func referrerManifestInfo(repo name.Repository, descDigest v1.Hash, ropt []remote.Option) (string, map[string]string, error) {
+	d, err := remote.Get(repo.Digest(descDigest.String()), ropt...)
+	if err != nil {
+		return "", nil, err
+	}
+	var mf struct {
+		ArtifactType string            `json:"artifactType"`
+		Annotations  map[string]string `json:"annotations"`
+	}
+	if err := json.Unmarshal(d.Manifest, &mf); err != nil {
+		return "", nil, fmt.Errorf("parsing referrer manifest %s: %w", descDigest, err)
+	}
+	return mf.ArtifactType, mf.Annotations, nil
 }
 
 // referrerDSSEPayload fetches the given referrer manifest, reads its first

--- a/pkg/private/secant/replace_referrers_test.go
+++ b/pkg/private/secant/replace_referrers_test.go
@@ -1,12 +1,18 @@
 package secant
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	dsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -127,5 +133,309 @@ func TestResolveBundleConflict_SkipSame(t *testing.T) {
 	}
 	if !shouldWrite {
 		t.Error("expected SKIPSAME to write a novel payload")
+	}
+}
+
+// bundleN returns testBundleBytes mutated so each call produces a distinct
+// referrer manifest digest (mirroring successive status writes with different
+// payloads).
+func bundleN(n int) []byte {
+	return fmt.Appendf(nil, `{"this":"stands in for a serialized sigstore bundle","n":%d}`, n)
+}
+
+// TestReplaceNoDangling drives two consecutive REPLACE writes for the same
+// subject + predicate type and asserts that exactly one consistent referrer
+// remains afterward, on both registry topologies.
+//
+// On a registry WITHOUT native Referrers API support this reproduces the bug
+// where REPLACE deletes the prior referrer manifest but leaves a dangling
+// descriptor in the sha256-<subject> fallback index. The second write's
+// commitSubjectReferrers then reads the stale index, appends the new
+// descriptor, and re-PUTs an index that still references the just-deleted
+// manifest; a registry that validates index members rejects the PUT with
+// MANIFEST_UNKNOWN. On a registry WITH native referrers support there is no
+// fallback index, so this is the control that confirms the same flow stays
+// clean.
+//
+// This drives the same code paths as two AttestBundle(..., Replace, ...) /
+// SignBundle(..., Replace, ...) writes (resolveBundleConflict + writeBundleReferrer)
+// without needing a real Fulcio/Rekor signer.
+func TestReplaceNoDangling(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		referrersSupport bool
+	}{
+		{"fallback tag index", false},
+		{"native referrers api", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newTestRepo(t, tc.referrersSupport)
+
+			img, err := random.Image(1024, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			subject := pushImage(t, repo, img)
+
+			ociOpts := []ociremote.Option{ociremote.WithRemoteOptions()}
+
+			// First write.
+			if _, err := resolveBundleConflict(subject, testPredicateType, bundleN(1), Replace, nil, ociOpts); err != nil {
+				t.Fatalf("first resolveBundleConflict: %v", err)
+			}
+			if err := writeBundleReferrer(subject, bundleN(1), testPredicateType, nil, nil); err != nil {
+				t.Fatalf("first writeBundleReferrer: %v", err)
+			}
+
+			// Second Replace write for the same subject + predicate type. On the
+			// fallback topology, pre-fix this fails inside commitSubjectReferrers
+			// because the fallback index still lists the referrer deleted by
+			// resolveBundleConflict.
+			if _, err := resolveBundleConflict(subject, testPredicateType, bundleN(2), Replace, nil, ociOpts); err != nil {
+				t.Fatalf("second resolveBundleConflict: %v", err)
+			}
+			if err := writeBundleReferrer(subject, bundleN(2), testPredicateType, nil, nil); err != nil {
+				t.Fatalf("second writeBundleReferrer: %v", err)
+			}
+
+			// Exactly one referrer must remain after the second Replace.
+			raws := referrerManifests(t, subject)
+			if len(raws) != 1 {
+				t.Fatalf("expected exactly 1 referrer after second Replace, got %d", len(raws))
+			}
+
+			// And the fallback index (if any) must reference only manifests that
+			// still exist. A no-op on the native registry, which has no fallback tag.
+			assertFallbackIndexConsistent(t, subject)
+		})
+	}
+}
+
+// TestPruneFallbackReferrersClearsDangling isolates the fallback-index dangling
+// bug from the referrer-matching bug. It writes a referrer, deletes its manifest
+// the way resolveBundleConflict's REPLACE branch does (remote.Delete, which does
+// not touch the fallback index), and then verifies that a fresh write succeeds.
+// It is inherently fallback-specific: a native-referrers registry has no
+// fallback index to leave dangling.
+//
+// Without pruning, the second write's commitSubjectReferrers reads the stale
+// sha256-<subject> index (still listing the deleted referrer), re-PUTs it with
+// the new descriptor appended, and the in-memory registry rejects the index PUT
+// with MANIFEST_UNKNOWN ("Sub-manifest <deleted digest> not found").
+func TestPruneFallbackReferrersClearsDangling(t *testing.T) {
+	repo := newTestRepo(t, false)
+
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject := pushImage(t, repo, img)
+
+	// Write a first referrer.
+	if err := writeBundleReferrer(subject, bundleN(1), testPredicateType, nil, nil); err != nil {
+		t.Fatalf("first writeBundleReferrer: %v", err)
+	}
+
+	// Find and delete it by digest, mirroring resolveBundleConflict's delete loop.
+	raws := referrerManifests(t, subject)
+	if len(raws) != 1 {
+		t.Fatalf("expected 1 referrer after first write, got %d", len(raws))
+	}
+	idx, err := remote.Referrers(subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	im, err := idx.IndexManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	deleted := make([]v1.Hash, 0, len(im.Manifests))
+	for _, m := range im.Manifests {
+		if err := remote.Delete(subject.Context().Digest(m.Digest.String())); err != nil {
+			t.Fatalf("deleting referrer %s: %v", m.Digest, err)
+		}
+		deleted = append(deleted, m.Digest)
+	}
+
+	// Prune the fallback index (the fix). Pre-fix this is a no-op and the next
+	// write fails; post-fix it removes the dangling descriptor.
+	if err := pruneFallbackReferrers(subject, deleted, nil); err != nil {
+		t.Fatalf("pruneFallbackReferrers: %v", err)
+	}
+
+	// A subsequent write must succeed and leave exactly one referrer.
+	if err := writeBundleReferrer(subject, bundleN(2), testPredicateType, nil, nil); err != nil {
+		t.Fatalf("second writeBundleReferrer (dangling fallback entry): %v", err)
+	}
+	if got := referrerManifests(t, subject); len(got) != 1 {
+		t.Fatalf("expected exactly 1 referrer after prune + rewrite, got %d", len(got))
+	}
+	assertFallbackIndexConsistent(t, subject)
+}
+
+// TestBundleReferrerMatches exercises bundleReferrerMatches's fast and slow
+// paths directly with synthetic referrers-index descriptors. The in-memory
+// registry never populates a referrers-index descriptor with both a bundle
+// artifactType and the predicate-type annotation (its native handler reports the
+// config media type and no annotations, and its fallback index omits
+// annotations), so neither TestReplaceNoDangling topology reaches the fast path.
+// Real registries (zot/GAR/ECR) do populate those fields, making the fast path
+// the production-relevant branch — this is its only coverage.
+//
+// The fast-path cases deliberately point at a missing or contradictory manifest
+// so that a regression which fell through to a manifest fetch would flip the
+// result, pinning "trust the index when it is populated".
+func TestBundleReferrerMatches(t *testing.T) {
+	repo := newTestRepo(t, false)
+
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject := pushImage(t, repo, img)
+
+	// One real referrer manifest carrying testPredicateType, so the slow path has
+	// an authoritative manifest to consult.
+	if err := writeBundleReferrer(subject, bundleN(1), testPredicateType, nil, nil); err != nil {
+		t.Fatalf("writeBundleReferrer: %v", err)
+	}
+	idx, err := remote.Referrers(subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	im, err := idx.IndexManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(im.Manifests) != 1 {
+		t.Fatalf("expected 1 referrer, got %d", len(im.Manifests))
+	}
+	realDigest := im.Manifests[0].Digest
+
+	bundleMediaType, err := sgbundle.MediaTypeString("0.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const otherPredicateType = "https://example.com/other/v1"
+	missing, err := v1.NewHash("sha256:" + strings.Repeat("ab", 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		desc      v1.Descriptor
+		predicate string
+		want      bool
+	}{
+		{
+			// Fast path: index carries bundle artifactType + matching predicate
+			// annotation. Digest is absent, so a stray manifest fetch would 404 and
+			// return false — want=true proves the index alone decided it.
+			name: "fast path match, index trusted without fetch",
+			desc: v1.Descriptor{
+				Digest:       missing,
+				ArtifactType: bundleMediaType,
+				Annotations:  map[string]string{ociremote.BundlePredicateType: testPredicateType},
+			},
+			predicate: testPredicateType,
+			want:      true,
+		},
+		{
+			// Fast path: index annotation names a different predicate. Digest points
+			// at the real manifest, whose predicate WOULD match — want=false proves
+			// the index annotation is authoritative and the manifest is not consulted.
+			name: "fast path predicate mismatch, manifest not consulted",
+			desc: v1.Descriptor{
+				Digest:       realDigest,
+				ArtifactType: bundleMediaType,
+				Annotations:  map[string]string{ociremote.BundlePredicateType: otherPredicateType},
+			},
+			predicate: testPredicateType,
+			want:      false,
+		},
+		{
+			// A non-bundle, non-empty artifactType must NOT short-circuit to a
+			// non-match: the OCI referrers spec lets a registry report the config
+			// descriptor's media type as the artifactType, and cosign bundles use the
+			// empty-config media type, so a real bundle can surface in the index with
+			// artifactType "application/vnd.oci.empty.v1+json" (exactly what
+			// go-containerregistry's in-memory native registry does). Digest points at
+			// the real bundle manifest, and want=true confirms we fall through to the
+			// authoritative manifest instead of trusting the non-bundle artifactType.
+			// This pins why bundleReferrerMatches cannot skip the fetch on a
+			// non-bundle artifactType.
+			name: "non-bundle artifactType still consults manifest",
+			desc: v1.Descriptor{
+				Digest:       realDigest,
+				ArtifactType: "application/vnd.oci.empty.v1+json",
+			},
+			predicate: testPredicateType,
+			want:      true,
+		},
+		{
+			// Slow path: bundle artifactType but no annotation (the ggcr fallback
+			// shape). The real manifest carries testPredicateType.
+			name: "slow path, annotation absent, manifest matches",
+			desc: v1.Descriptor{
+				Digest:       realDigest,
+				ArtifactType: bundleMediaType,
+			},
+			predicate: testPredicateType,
+			want:      true,
+		},
+		{
+			// Slow path: same manifest, queried for a different predicate type.
+			name: "slow path, manifest predicate differs",
+			desc: v1.Descriptor{
+				Digest: realDigest,
+			},
+			predicate: otherPredicateType,
+			want:      false,
+		},
+		{
+			// Slow path: descriptor for an already-deleted manifest (dangling
+			// fallback-index entry) is not a match and not an error.
+			name: "slow path, dangling referrer 404s to non-match",
+			desc: v1.Descriptor{
+				Digest: missing,
+			},
+			predicate: testPredicateType,
+			want:      false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := bundleReferrerMatches(subject.Context(), tc.desc, tc.predicate, nil)
+			if err != nil {
+				t.Fatalf("bundleReferrerMatches: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("bundleReferrerMatches = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// assertFallbackIndexConsistent fetches the sha256-<subject> fallback-tag index
+// directly and verifies every descriptor it lists resolves to a real manifest.
+// On a registry with native Referrers API support there is no fallback tag, so
+// the index GET 404s and this returns without asserting anything.
+func assertFallbackIndexConsistent(t *testing.T, subject name.Digest) {
+	t.Helper()
+
+	tag := subject.Context().Tag(strings.Replace(subject.DigestStr(), ":", "-", 1))
+	idx, err := remote.Index(tag)
+	if err != nil {
+		// No fallback tag (native referrers, or nothing written) is fine.
+		return
+	}
+	im, err := idx.IndexManifest()
+	if err != nil {
+		t.Fatalf("parsing fallback index: %v", err)
+	}
+	for _, desc := range im.Manifests {
+		if _, err := remote.Get(subject.Context().Digest(desc.Digest.String())); err != nil {
+			t.Errorf("fallback index references missing manifest %s: %v", desc.Digest, err)
+		}
 	}
 }

--- a/pkg/private/secant/writereferrer_test.go
+++ b/pkg/private/secant/writereferrer_test.go
@@ -26,9 +26,22 @@ const testPredicateType = "https://slsa.dev/provenance/v1"
 var testBundleBytes = []byte(`{"this":"stands in for a serialized sigstore bundle"}`)
 
 func setupTestRepo(t *testing.T) name.Repository {
+	return newTestRepo(t, true)
+}
+
+// newTestRepo stands up an in-memory registry, with or without native Referrers
+// API support, and returns a repository under it.
+//
+// With referrers support disabled, go-containerregistry tracks referrers via
+// the sha256-<subject> fallback-tag index. That is the configuration which
+// exercises the commitSubjectReferrers fallback path and the stale-index bug.
+// With it enabled, the registry computes referrers dynamically and maintains no
+// fallback tag, so the REPLACE delete+rewrite cycle has no client-side index to
+// leave dangling — the control case that must also stay clean.
+func newTestRepo(t *testing.T, referrersSupport bool) name.Repository {
 	t.Helper()
 
-	srv := httptest.NewServer(registry.New(registry.WithReferrersSupport(true)))
+	srv := httptest.NewServer(registry.New(registry.WithReferrersSupport(referrersSupport)))
 	t.Cleanup(srv.Close)
 
 	repo, err := name.NewRepository(strings.TrimPrefix(srv.URL, "http://") + "/test-repo")


### PR DESCRIPTION
#566 made REPLACE/SKIPSAME correctly identify existing bundle referrers on registries that omit annotations from the referrers index, but REPLACE was still broken on the write side for those same registries. On a registry without the native Referrers API, go-containerregistry maintains referrers in a client-side sha256-<subject> fallback-tag index, and remote.Delete removes the referrer manifest without pruning that index (a documented gap in its Pusher.Delete). The next write reads the stale index, appends the new referrer, and re-PUTs an index still pointing at the just-deleted manifest — which a registry that validates index members rejects with MANIFEST_UNKNOWN, so the second REPLACE for a given subject fails.

This prunes the deleted descriptors from the fallback index right after the delete, so the subsequent write commits a consistent index. It's a no-op on registries with the native Referrers API, which compute referrers dynamically and keep no fallback tag. The 404 check and the referrer-manifest fetch are factored into isReferrerNotFound and referrerManifestInfo, the former now shared with the prune.

Tests live with #566's in replace_referrers_test.go: TestReplaceNoDangling drives two consecutive REPLACEs across both registry topologies, TestPruneFallbackReferrersClearsDangling isolates the prune, and TestBundleReferrerMatches pins the fast/slow matching paths including the case where a registry reports the config media type as the artifactType.

Assisted by Claude Opus 4.8 (1M context)