### PR TITLE
fix(secant): SKIPSAME supersedes prior bundles instead of appending

### DIFF
--- a/pkg/private/secant/bundlesign.go
+++ b/pkg/private/secant/bundlesign.go
@@ -297,9 +297,12 @@ func AttestBundle(ctx context.Context, conflict string, statements []*types.Stat
 }
 
 // resolveBundleConflict applies the conflict policy to a pending bundle write.
-// It returns whether the caller should proceed with the write, after
-// optionally deleting existing referrers for REPLACE. The write may still be
-// needed under SKIPSAME if no existing referrer has an identical payload.
+// It returns whether the caller should proceed with the write, after deleting
+// the existing referrers the write supersedes. REPLACE deletes every matching
+// referrer; SKIPSAME keeps one whose payload is byte-identical to the pending
+// write (skipping the write) and deletes the rest. Both modes converge on a
+// single bundle per predicate type, so accumulation cannot outlive the next
+// write even on repositories whose retention never reaps referrer manifests.
 func resolveBundleConflict(digest name.Digest, predicateType string, newPayload []byte, conflict string, ropt []remote.Option, opts []ociremote.Option) (bool, error) {
 	switch conflict {
 	case "", Append:
@@ -314,6 +317,7 @@ func resolveBundleConflict(digest name.Digest, predicateType string, newPayload 
 		return false, err
 	}
 
+	var keep *v1.Hash
 	if conflict == SkipSame {
 		for _, m := range matching {
 			payload, err := referrerDSSEPayload(digest.Repository, m.Digest, ropt)
@@ -327,21 +331,26 @@ func resolveBundleConflict(digest name.Digest, predicateType string, newPayload 
 				return false, fmt.Errorf("reading referrer %s: %w", m.Digest, err)
 			}
 			if bytes.Equal(payload, newPayload) {
-				return false, nil
+				d := m.Digest
+				keep = &d
+				break
 			}
 		}
-		return true, nil
 	}
 
 	deleted := make([]v1.Hash, 0, len(matching))
 	for _, m := range matching {
+		if keep != nil && m.Digest == *keep {
+			continue
+		}
 		ref := digest.Digest(m.Digest.String())
 		if err := remote.Delete(ref, ropt...); err != nil && !isReferrerNotFound(err) {
 			return false, fmt.Errorf("deleting referrer %s: %w", m.Digest, err)
 		}
 		// A NOT_FOUND delete means a stale referrers-index entry whose manifest
-		// is already gone — the outcome REPLACE wants. Record it as deleted so
-		// pruneFallbackReferrers also drops it from a fallback-tag index.
+		// is already gone — the outcome the conflict policy wants. Record it as
+		// deleted so pruneFallbackReferrers also drops it from a fallback-tag
+		// index.
 		deleted = append(deleted, m.Digest)
 	}
 
@@ -357,7 +366,7 @@ func resolveBundleConflict(digest name.Digest, predicateType string, newPayload 
 	if err := pruneFallbackReferrers(digest, deleted, ropt); err != nil {
 		return false, fmt.Errorf("pruning fallback referrers for %q: %w", digest.String(), err)
 	}
-	return true, nil
+	return keep == nil, nil
 }
 
 // pruneFallbackReferrers removes the given descriptors from the sha256-<subject>

--- a/pkg/private/secant/replace_referrers_test.go
+++ b/pkg/private/secant/replace_referrers_test.go
@@ -1,6 +1,7 @@
 package secant
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"testing"
@@ -98,9 +99,10 @@ func TestMatchingBundleReferrers_ManifestSourced(t *testing.T) {
 	}
 }
 
-// TestResolveBundleConflict_SkipSame confirms SKIPSAME skips an identical
-// payload but writes a novel one, on a registry whose referrers index omits
-// annotations.
+// TestResolveBundleConflict_SkipSame confirms SKIPSAME converges on a single
+// bundle per predicate type: an identical payload is kept (and the write
+// skipped) while every other matching referrer is deleted, and a novel
+// payload deletes all priors before requesting the write.
 func TestResolveBundleConflict_SkipSame(t *testing.T) {
 	repo := setupTestRepo(t)
 
@@ -114,10 +116,17 @@ func TestResolveBundleConflict_SkipSame(t *testing.T) {
 	if err := writeBundleReferrer(subject, bundleWithDSSEPayload(t, payload), testPredicateType, nil, nil); err != nil {
 		t.Fatalf("writing referrer: %v", err)
 	}
+	// A superseded prior from an earlier write with a different payload,
+	// mirroring the bundle-per-epoch accumulation a retention policy that
+	// cannot see referrer manifests never reaps.
+	if err := writeBundleReferrer(subject, bundleWithDSSEPayload(t, []byte(`{"_type":"stale"}`)), testPredicateType, nil, nil); err != nil {
+		t.Fatalf("writing superseded referrer: %v", err)
+	}
 
 	opts := []ociremote.Option{ociremote.WithRemoteOptions()}
 
-	// Identical payload: SKIPSAME must skip the write.
+	// Identical payload present: SKIPSAME must skip the write, keep the
+	// identical bundle, and delete the superseded one.
 	shouldWrite, err := resolveBundleConflict(subject, testPredicateType, payload, SkipSame, nil, opts)
 	if err != nil {
 		t.Fatalf("resolveBundleConflict(SkipSame, identical): %v", err)
@@ -125,14 +134,33 @@ func TestResolveBundleConflict_SkipSame(t *testing.T) {
 	if shouldWrite {
 		t.Error("expected SKIPSAME to skip an identical payload")
 	}
+	matching, err := matchingBundleReferrers(subject, testPredicateType, opts, nil)
+	if err != nil {
+		t.Fatalf("matchingBundleReferrers after identical: %v", err)
+	}
+	if len(matching) != 1 {
+		t.Fatalf("expected the identical bundle to remain alone, got %d referrers", len(matching))
+	}
+	if kept, err := referrerDSSEPayload(subject.Repository, matching[0].Digest, nil); err != nil {
+		t.Fatalf("reading kept referrer: %v", err)
+	} else if !bytes.Equal(kept, payload) {
+		t.Errorf("kept payload: got = %s, want = %s", kept, payload)
+	}
 
-	// Different payload: SKIPSAME must request the write.
+	// Different payload: SKIPSAME must delete the prior and request the write.
 	shouldWrite, err = resolveBundleConflict(subject, testPredicateType, []byte(`{"_type":"differs"}`), SkipSame, nil, opts)
 	if err != nil {
 		t.Fatalf("resolveBundleConflict(SkipSame, different): %v", err)
 	}
 	if !shouldWrite {
 		t.Error("expected SKIPSAME to write a novel payload")
+	}
+	remaining, err := matchingBundleReferrers(subject, testPredicateType, opts, nil)
+	if err != nil {
+		t.Fatalf("matchingBundleReferrers after different: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("expected SKIPSAME to delete superseded referrers, got %d remaining", len(remaining))
 	}
 }
 


### PR DESCRIPTION
The SKIPSAME conflict mode documents itself as 'skips writing identical signatures but otherwise replaces', and the legacy tag-based signature path honors that. The bundle/referrers path diverged: it skipped the write when an existing referrer carried a byte-identical payload, but otherwise wrote the new bundle alongside every prior one, deleting nothing.

That leaves one superseded bundle behind per payload change. On registries whose retention cannot see referrer manifests (Artifact Registry cleanup policies operate on versions, and referrer manifests are not versions), the accumulation is unbounded, and every consumer that reads the referrers to find the latest bundle pays for each abandoned prior: N manifest and blob fetches and N verifications per read, growing with every write.

Align the bundle path with the documented contract: SKIPSAME keeps a referrer whose payload is byte-identical to the pending write (and skips the write) and deletes the rest, exactly as REPLACE deletes all. Both modes now converge on a single bundle per predicate type, so accumulation cannot outlive the next write. Stale referrers-index tolerance and fallback-tag pruning apply to the deletions as they do under REPLACE.