### PR TITLE
Suppress zizmor dangerous-triggers finding on test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: Tests
 
 on:
-  pull_request_target:
+  # pull_request_target is deliberate: fork PRs need the OIDC token for the
+  # keyless signing tests, which plain pull_request does not grant them.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     branches:
       - "main"
   push:


### PR DESCRIPTION
pull_request_target is deliberate here: fork PRs need id-token:write for the keyless signing tests, and the trigger comment documents the mitigations. Matches how terraform-provider-chainguard suppresses the same finding.
