### PR TITLE
secant: add rekor rate limiter wait-duration metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/in-toto/attestation v1.2.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/secure-systems-lab/go-securesystemslib v0.11.0
 	github.com/sigstore/cosign/v3 v3.1.1
 	github.com/sigstore/fulcio v1.8.8
@@ -248,7 +249,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/posener/complete v1.2.3 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.68.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/pkg/private/secant/attest.go
+++ b/pkg/private/secant/attest.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"time"
 
 	rekordsse "github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/models/dsse"
 	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/models/intoto"
@@ -114,10 +113,7 @@ func AttestEntity(ctx context.Context, se oci.SignedEntity, conflict string, sta
 	if RekorRateLimiter != nil {
 		// Wait to ensure we don't hit Rekor rate limits.
 		// Wait up front for enough tokens to attest all statements to reduce likelihood of partial failure due to context cancellation.
-		start := time.Now()
-		err := RekorRateLimiter.WaitN(ctx, len(statements))
-		tlog.RekorRateLimiterWaitSeconds.Observe(time.Since(start).Seconds())
-		if err != nil {
+		if err := RekorRateLimiter.WaitN(ctx, len(statements)); err != nil {
 			return nil, fmt.Errorf("waiting for rekor rate limiter: %w", err)
 		}
 	}

--- a/pkg/private/secant/attest.go
+++ b/pkg/private/secant/attest.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"time"
 
 	rekordsse "github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/models/dsse"
 	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/models/intoto"
@@ -17,6 +18,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/cosign/v3/pkg/cosign/attestation"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
@@ -41,6 +43,13 @@ var (
 // 5 QPS limit. Aliased to tlog.RekorRateLimiter so the same instance governs
 // both the pre-call waits here and the retry-time waits inside tlog.Upload.
 var RekorRateLimiter = tlog.RekorRateLimiter
+
+// RegisterMetrics registers secant's collectors with r. Hosts that scrape
+// metrics call this once (typically with prometheus.DefaultRegisterer); the
+// Terraform provider never does, so its observations stay uncollected.
+func RegisterMetrics(r prometheus.Registerer) error {
+	return tlog.RegisterMetrics(r)
+}
 
 // NewStatement generates a statement for use in Attest.
 func NewStatement(digest name.Digest, predicate io.Reader, ptype string) (*types.Statement, error) {
@@ -105,7 +114,10 @@ func AttestEntity(ctx context.Context, se oci.SignedEntity, conflict string, sta
 	if RekorRateLimiter != nil {
 		// Wait to ensure we don't hit Rekor rate limits.
 		// Wait up front for enough tokens to attest all statements to reduce likelihood of partial failure due to context cancellation.
-		if err := RekorRateLimiter.WaitN(ctx, len(statements)); err != nil {
+		start := time.Now()
+		err := RekorRateLimiter.WaitN(ctx, len(statements))
+		tlog.RekorRateLimiterWaitSeconds.Observe(time.Since(start).Seconds())
+		if err != nil {
 			return nil, fmt.Errorf("waiting for rekor rate limiter: %w", err)
 		}
 	}

--- a/pkg/private/secant/sign.go
+++ b/pkg/private/secant/sign.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/rekor"
-	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/tlog"
 	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/types"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -69,10 +67,7 @@ func SignEntity(ctx context.Context, se oci.SignedEntity, subject name.Digest, c
 	// We intentionally throttle after we've evaluated SKIP_SAME (so we don't throttle if we're not going to call Rekor)
 	// and before signing the payload (to ensure our signature is valid when uploading to Rekor)
 	if RekorRateLimiter != nil {
-		start := time.Now()
-		err := RekorRateLimiter.Wait(ctx)
-		tlog.RekorRateLimiterWaitSeconds.Observe(time.Since(start).Seconds())
-		if err != nil {
+		if err := RekorRateLimiter.Wait(ctx); err != nil {
 			return nil, fmt.Errorf("waiting for rekor rate limiter: %w", err)
 		}
 	}

--- a/pkg/private/secant/sign.go
+++ b/pkg/private/secant/sign.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/rekor"
+	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/tlog"
 	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/types"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -67,7 +69,10 @@ func SignEntity(ctx context.Context, se oci.SignedEntity, subject name.Digest, c
 	// We intentionally throttle after we've evaluated SKIP_SAME (so we don't throttle if we're not going to call Rekor)
 	// and before signing the payload (to ensure our signature is valid when uploading to Rekor)
 	if RekorRateLimiter != nil {
-		if err := RekorRateLimiter.Wait(ctx); err != nil {
+		start := time.Now()
+		err := RekorRateLimiter.Wait(ctx)
+		tlog.RekorRateLimiterWaitSeconds.Observe(time.Since(start).Seconds())
+		if err != nil {
 			return nil, fmt.Errorf("waiting for rekor rate limiter: %w", err)
 		}
 	}

--- a/pkg/private/secant/tlog/tlog.go
+++ b/pkg/private/secant/tlog/tlog.go
@@ -32,21 +32,39 @@ import (
 // RekorRateLimiter throttles all calls to Rekor (including retries from
 // createLogEntryWithRetry) to stay within rate limits. Defaults to 5 QPS with
 // a burst of 50.
-var RekorRateLimiter = rate.NewLimiter(5.0, 50)
+var RekorRateLimiter = &RateLimiter{limiter: rate.NewLimiter(5.0, 50)}
 
-// RekorRateLimiterWaitSeconds records how long callers block acquiring tokens
-// from RekorRateLimiter, across all of its wait call sites. It is left
-// unregistered so only hosts that opt in via RegisterMetrics gather it.
-var RekorRateLimiterWaitSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
-	Name:    "secant_rekor_ratelimiter_wait_duration_seconds",
+// rekorWaitSeconds is left unregistered so only hosts that opt in via
+// RegisterMetrics gather it.
+var rekorWaitSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name:    "secant_rekor_rate_limiter_wait_duration_seconds",
 	Help:    "Seconds spent blocked acquiring tokens from the Rekor rate limiter.",
-	Buckets: prometheus.DefBuckets,
+	Buckets: prometheus.ExponentialBuckets(0.001, 3, 12),
 })
 
 // RegisterMetrics registers the tlog collectors with r. Hosts that scrape
 // metrics call this once; the Terraform provider never does.
 func RegisterMetrics(r prometheus.Registerer) error {
-	return r.Register(RekorRateLimiterWaitSeconds)
+	return r.Register(rekorWaitSeconds)
+}
+
+// RateLimiter throttles acquires and records how long each one blocks.
+type RateLimiter struct {
+	limiter *rate.Limiter
+}
+
+func (r *RateLimiter) Wait(ctx context.Context) error {
+	start := time.Now()
+	err := r.limiter.Wait(ctx)
+	rekorWaitSeconds.Observe(time.Since(start).Seconds())
+	return err
+}
+
+func (r *RateLimiter) WaitN(ctx context.Context, n int) error {
+	start := time.Now()
+	err := r.limiter.WaitN(ctx, n)
+	rekorWaitSeconds.Observe(time.Since(start).Seconds())
+	return err
 }
 
 const createLogEntryMaxAttempts = 5
@@ -131,10 +149,7 @@ func createLogEntryWithRetry(ctx context.Context, create func() (*entries.Create
 			return nil, ctx.Err()
 		case <-time.After(backoff):
 		}
-		start := time.Now()
-		err = RekorRateLimiter.Wait(ctx)
-		RekorRateLimiterWaitSeconds.Observe(time.Since(start).Seconds())
-		if err != nil {
+		if err := RekorRateLimiter.Wait(ctx); err != nil {
 			return nil, fmt.Errorf("waiting for rekor rate limiter: %w", err)
 		}
 		backoff *= 2

--- a/pkg/private/secant/tlog/tlog.go
+++ b/pkg/private/secant/tlog/tlog.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+	"github.com/prometheus/client_golang/prometheus"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
@@ -32,6 +33,21 @@ import (
 // createLogEntryWithRetry) to stay within rate limits. Defaults to 5 QPS with
 // a burst of 50.
 var RekorRateLimiter = rate.NewLimiter(5.0, 50)
+
+// RekorRateLimiterWaitSeconds records how long callers block acquiring tokens
+// from RekorRateLimiter, across all of its wait call sites. It is left
+// unregistered so only hosts that opt in via RegisterMetrics gather it.
+var RekorRateLimiterWaitSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name:    "secant_rekor_ratelimiter_wait_duration_seconds",
+	Help:    "Seconds spent blocked acquiring tokens from the Rekor rate limiter.",
+	Buckets: prometheus.DefBuckets,
+})
+
+// RegisterMetrics registers the tlog collectors with r. Hosts that scrape
+// metrics call this once; the Terraform provider never does.
+func RegisterMetrics(r prometheus.Registerer) error {
+	return r.Register(RekorRateLimiterWaitSeconds)
+}
 
 const createLogEntryMaxAttempts = 5
 
@@ -115,7 +131,10 @@ func createLogEntryWithRetry(ctx context.Context, create func() (*entries.Create
 			return nil, ctx.Err()
 		case <-time.After(backoff):
 		}
-		if err := RekorRateLimiter.Wait(ctx); err != nil {
+		start := time.Now()
+		err = RekorRateLimiter.Wait(ctx)
+		RekorRateLimiterWaitSeconds.Observe(time.Since(start).Seconds())
+		if err != nil {
 			return nil, fmt.Errorf("waiting for rekor rate limiter: %w", err)
 		}
 		backoff *= 2

--- a/pkg/private/secant/tlog/tlog_test.go
+++ b/pkg/private/secant/tlog/tlog_test.go
@@ -8,8 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
 )
+
+func TestRegisterMetrics(t *testing.T) {
+	if err := RegisterMetrics(prometheus.NewRegistry()); err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+}
 
 func TestIsRetryableRekorError(t *testing.T) {
 	for _, tc := range []struct {

--- a/pkg/private/secant/tlog/tlog_test.go
+++ b/pkg/private/secant/tlog/tlog_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
 )
 
@@ -43,6 +44,8 @@ func TestIsRetryableRekorError(t *testing.T) {
 func TestCreateLogEntryWithRetry_RetriesTransient(t *testing.T) {
 	defer shrinkRetryBackoff(t)()
 
+	before := waitObservationCount(t)
+
 	var attempts int
 	transient := errors.New("stream error: stream ID 1; INTERNAL_ERROR; received from peer")
 
@@ -62,6 +65,22 @@ func TestCreateLogEntryWithRetry_RetriesTransient(t *testing.T) {
 	if attempts != 3 {
 		t.Errorf("attempts = %d, want 3", attempts)
 	}
+
+	// The rate limiter is waited on before each retry, so two failed attempts
+	// record two wait observations.
+	if got, want := waitObservationCount(t)-before, uint64(attempts-1); got != want {
+		t.Errorf("recorded %d wait observations, want %d", got, want)
+	}
+}
+
+// waitObservationCount returns how many samples rekorWaitSeconds has recorded.
+func waitObservationCount(t *testing.T) uint64 {
+	t.Helper()
+	var m dto.Metric
+	if err := rekorWaitSeconds.Write(&m); err != nil {
+		t.Fatalf("writing metric: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
 }
 
 func TestCreateLogEntryWithRetry_StopsOnConflict(t *testing.T) {


### PR DESCRIPTION
Signing throughput is capped by secant's Rekor rate limiter, but we can't see how long callers spend blocked in it. Add a histogram of seconds spent blocked, observed at each of the limiter's wait call sites. The collector is an unregistered package var, so any consumer of the package can opt in with RegisterMetrics (the terraform provider itself doesn't).

Ref CON-2107