### PR TITLE
Add a chainguard-token-cache OIDC provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -83,3 +83,4 @@ resource "cosign_attest" "example" {
 | TF_COSIGN_CLIENT_SECRET |                                  | Configures Sigstore OAuth Client Secret.                                                       |
 | TF_COSIGN_REDIRECT_URL  |                                  | Configures Sigstore interactive OAuth redirect URL. If empty, a random localhost port is used. |
 | TF_COSIGN_DISABLE       |                                  | Disables all cosign operations.                                                                |
+| TF_COSIGN_CHAINGUARD_TOKEN_CACHE |                         | Sources OIDC tokens from the Chainguard token cache (`<user cache dir>/chainguard/<audience>/oidc-token`); an absolute path value overrides the cache root. When set, an unreadable token fails the operation instead of skipping signing. |

--- a/internal/provider/chainguardcache/chainguardcache.go
+++ b/internal/provider/chainguardcache/chainguardcache.go
@@ -1,0 +1,63 @@
+// Package chainguardcache provides OIDC tokens from the Chainguard token
+// cache: the chainctl-convention layout at
+// <user cache dir>/chainguard/<escaped audience>/oidc-token.
+//
+// It is intended for environments where that path is backed by a credential
+// filesystem minting a fresh token on every read, so each signing operation
+// presents a current token. Unlike ambient detection, enabling is explicit
+// (TF_COSIGN_CHAINGUARD_TOKEN_CACHE): when set, an unreadable or empty token
+// fails the operation instead of the provider chain silently skipping
+// signing.
+package chainguardcache
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sigstore/cosign/v3/pkg/providers"
+)
+
+// envVar enables the provider. Any non-empty value enables it; a value that
+// is an absolute path additionally overrides the cache root, replacing
+// <user cache dir>/chainguard.
+const envVar = "TF_COSIGN_CHAINGUARD_TOKEN_CACHE"
+
+func init() {
+	providers.Register("chainguard-token-cache", &provider{})
+}
+
+type provider struct{}
+
+var _ providers.Interface = (*provider)(nil)
+
+// Enabled implements providers.Interface.
+func (p *provider) Enabled(context.Context) bool {
+	return os.Getenv(envVar) != ""
+}
+
+// Provide implements providers.Interface.
+func (p *provider) Provide(_ context.Context, audience string) (string, error) {
+	root := os.Getenv(envVar)
+	if !filepath.IsAbs(root) {
+		dir, err := os.UserCacheDir()
+		if err != nil {
+			return "", fmt.Errorf("chainguard token cache: resolving user cache dir: %w", err)
+		}
+		root = filepath.Join(dir, "chainguard")
+	}
+	// The chainctl cache convention names each audience directory with path
+	// separators replaced, so the audience cannot traverse out of the root.
+	path := filepath.Join(root, strings.ReplaceAll(audience, "/", "-"), "oidc-token")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("chainguard token cache: %w", err)
+	}
+	token := strings.TrimSpace(string(b))
+	if token == "" {
+		return "", fmt.Errorf("chainguard token cache: %s is empty", path)
+	}
+	return token, nil
+}

--- a/internal/provider/chainguardcache/chainguardcache_test.go
+++ b/internal/provider/chainguardcache/chainguardcache_test.go
@@ -1,0 +1,106 @@
+package chainguardcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeToken(t *testing.T, root, audience, token string) {
+	t.Helper()
+	dir := filepath.Join(root, audience)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "oidc-token"), []byte(token), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	p := &provider{}
+
+	t.Run("disabled without the env var", func(t *testing.T) {
+		t.Setenv(envVar, "")
+		if p.Enabled(t.Context()) {
+			t.Error("Enabled() = true, want false")
+		}
+	})
+
+	t.Run("enabled with any non-empty value", func(t *testing.T) {
+		t.Setenv(envVar, "1")
+		if !p.Enabled(t.Context()) {
+			t.Error("Enabled() = false, want true")
+		}
+	})
+}
+
+func TestProvide(t *testing.T) {
+	p := &provider{}
+
+	t.Run("reads from the default cache location", func(t *testing.T) {
+		// os.UserCacheDir resolves from XDG_CACHE_HOME on linux and HOME on
+		// darwin; point both at temp dirs and write where it answers.
+		t.Setenv("XDG_CACHE_HOME", t.TempDir())
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv(envVar, "1")
+
+		root, err := os.UserCacheDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeToken(t, filepath.Join(root, "chainguard"), "sigstore", "tok-abc\n")
+
+		got, err := p.Provide(t.Context(), "sigstore")
+		if err != nil {
+			t.Fatalf("Provide: %v", err)
+		}
+		if got != "tok-abc" {
+			t.Errorf("Provide() = %q, want %q", got, "tok-abc")
+		}
+	})
+
+	t.Run("absolute env value overrides the cache root", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv(envVar, root)
+		writeToken(t, root, "sigstore", "tok-override")
+
+		got, err := p.Provide(t.Context(), "sigstore")
+		if err != nil {
+			t.Fatalf("Provide: %v", err)
+		}
+		if got != "tok-override" {
+			t.Errorf("Provide() = %q, want %q", got, "tok-override")
+		}
+	})
+
+	t.Run("escapes audience path separators like chainctl", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv(envVar, root)
+		writeToken(t, root, "https:--issuer.example.dev", "tok-esc")
+
+		got, err := p.Provide(t.Context(), "https://issuer.example.dev")
+		if err != nil {
+			t.Fatalf("Provide: %v", err)
+		}
+		if got != "tok-esc" {
+			t.Errorf("Provide() = %q, want %q", got, "tok-esc")
+		}
+	})
+
+	t.Run("missing token errors instead of skipping", func(t *testing.T) {
+		t.Setenv(envVar, t.TempDir())
+		if _, err := p.Provide(t.Context(), "sigstore"); err == nil {
+			t.Error("Provide() = nil error, want read failure")
+		}
+	})
+
+	t.Run("empty token errors", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv(envVar, root)
+		writeToken(t, root, "sigstore", "  \n")
+		if _, err := p.Provide(t.Context(), "sigstore"); err == nil {
+			t.Error("Provide() = nil error, want empty-token failure")
+		}
+	})
+}

--- a/internal/provider/oidc.go
+++ b/internal/provider/oidc.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sigstore/cosign/v3/pkg/providers"
 
+	_ "github.com/chainguard-dev/terraform-provider-cosign/internal/provider/chainguardcache"
 	_ "github.com/chainguard-dev/terraform-provider-cosign/internal/provider/interactive"
 	_ "github.com/sigstore/cosign/v3/pkg/providers/envvar"
 	_ "github.com/sigstore/cosign/v3/pkg/providers/filesystem"

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -43,3 +43,4 @@ OCI providers such as [`ko`](https://github.com/ko-build/terraform-provider-ko),
 | TF_COSIGN_CLIENT_SECRET |                                  | Configures Sigstore OAuth Client Secret.                                                       |
 | TF_COSIGN_REDIRECT_URL  |                                  | Configures Sigstore interactive OAuth redirect URL. If empty, a random localhost port is used. |
 | TF_COSIGN_DISABLE       |                                  | Disables all cosign operations.                                                                |
+| TF_COSIGN_CHAINGUARD_TOKEN_CACHE |                         | Sources OIDC tokens from the Chainguard token cache (`<user cache dir>/chainguard/<audience>/oidc-token`); an absolute path value overrides the cache root. When set, an unreadable token fails the operation instead of skipping signing. |


### PR DESCRIPTION
Sandboxed CI environments can deliver audience-scoped OIDC tokens through a credential filesystem laid out like the chainctl token cache (<user cache dir>/chainguard/<audience>/oidc-token), where every read mints a fresh token. None of the existing ambient providers can consume that: SIGSTORE_ID_TOKEN is a static value that goes stale over a long apply, and the cosign filesystem provider reads a fixed /var/run path such a sandbox cannot populate without shell workarounds.

The new provider reads the requested audience's token from that cache, gated on TF_COSIGN_CHAINGUARD_TOKEN_CACHE (an absolute-path value overrides the cache root). Enabling is explicit rather than detected, so an unreadable or empty token fails the sign/attest operation instead of the provider chain silently skipping signing.
