### PR TITLE
secant: retry and rate-limit the bundle signing path

### DIFF
--- a/pkg/private/secant/attest.go
+++ b/pkg/private/secant/attest.go
@@ -47,7 +47,10 @@ var RekorRateLimiter = tlog.RekorRateLimiter
 // metrics call this once (typically with prometheus.DefaultRegisterer); the
 // Terraform provider never does, so its observations stay uncollected.
 func RegisterMetrics(r prometheus.Registerer) error {
-	return tlog.RegisterMetrics(r)
+	if err := tlog.RegisterMetrics(r); err != nil {
+		return err
+	}
+	return r.Register(bundleSignRetries)
 }
 
 // NewStatement generates a statement for use in Attest.

--- a/pkg/private/secant/bundlesign.go
+++ b/pkg/private/secant/bundlesign.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/fulcio"
+	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/tlog"
 	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/types"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -22,6 +23,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	ggcrtypes "github.com/google/go-containerregistry/pkg/v1/types"
 	intotov1 "github.com/in-toto/attestation/go/v1"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
@@ -32,6 +34,27 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+// BundleRateLimiter throttles bundle signing attempts (including retries) to
+// stay within Fulcio/Rekor rate limits. Defaults to 5 QPS with a burst of 50.
+// Aliased to tlog.BundleRateLimiter, next to the RekorRateLimiter alias in
+// attest.go, so consumers find both knobs in one place. Set to nil to disable.
+var BundleRateLimiter = tlog.BundleRateLimiter
+
+// bundleSignRetries counts signing attempts that failed and were retried.
+// Left unregistered so only hosts that opt in via RegisterMetrics gather it.
+var bundleSignRetries = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "secant_bundle_sign_retries_total",
+	Help: "Number of bundle signing attempts retried after a failure.",
+})
+
+const bundleSignMaxAttempts = 5
+
+// Exposed as a var so tests can shrink the delay.
+var bundleSignInitialBackoff = 500 * time.Millisecond
+
+// signData is cbundle.SignData, indirected so tests can inject failures.
+var signData = cbundle.SignData
 
 // BundleSigner holds the materials needed for the cosign v3 bundle signing path.
 // The ephemeral keypair is generated once and reused across all operations.
@@ -111,7 +134,7 @@ func (bs *BundleSigner) signWithIDToken(ctx context.Context, content sign.Conten
 		return nil, fmt.Errorf("retrieving ID token: %w", err)
 	}
 
-	bundleBytes, err := cbundle.SignData(ctx, content, bs.keypair, idToken, nil, nil, bs.signingConfig, bs.trustedMaterial, cbundle.SignOptions{})
+	bundleBytes, err := signData(ctx, content, bs.keypair, idToken, nil, nil, bs.signingConfig, bs.trustedMaterial, cbundle.SignOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("signing bundle: %w", err)
 	}
@@ -157,11 +180,43 @@ func (bs *BundleSigner) certNeedsRefresh() bool {
 }
 
 // SignContent creates a protobuf bundle by signing the given content.
+// Each attempt first takes a token from BundleRateLimiter (if non-nil), and
+// failed attempts are retried with exponential backoff, up to
+// bundleSignMaxAttempts total. Errors are not classified: the signing chain
+// (Fulcio, TSA, Rekor) surfaces wrapped, untyped errors, so everything except
+// context cancellation is treated as transient. Attempts are bounded, so
+// misclassifying a terminal error costs at most a few extra round trips.
+func (bs *BundleSigner) SignContent(ctx context.Context, content sign.Content) ([]byte, error) {
+	backoff := bundleSignInitialBackoff
+	for attempt := 1; ; attempt++ {
+		if BundleRateLimiter != nil {
+			if err := BundleRateLimiter.Wait(ctx); err != nil {
+				return nil, fmt.Errorf("waiting for bundle rate limiter: %w", err)
+			}
+		}
+		bundleBytes, err := bs.signContentOnce(ctx, content)
+		if err == nil {
+			return bundleBytes, nil
+		}
+		if ctx.Err() != nil || attempt == bundleSignMaxAttempts {
+			return nil, err
+		}
+		bundleSignRetries.Inc()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
+}
+
+// signContentOnce performs a single signing attempt.
 // On first call (or when the cached cert is nearing expiry), delegates to
 // cbundle.SignData with an OIDC token, which fetches a new Fulcio cert
 // internally. The cert is extracted from the bundle and cached so that
 // subsequent calls pass it directly, skipping Fulcio entirely.
-func (bs *BundleSigner) SignContent(ctx context.Context, content sign.Content) ([]byte, error) {
+func (bs *BundleSigner) signContentOnce(ctx context.Context, content sign.Content) ([]byte, error) {
 	// Lock scope is deliberately split: we hold the mutex across a cert
 	// refresh so concurrent callers coalesce onto a single Fulcio fetch,
 	// but release it before the steady-state sign so cached-cert signs
@@ -185,7 +240,7 @@ func (bs *BundleSigner) SignContent(ctx context.Context, content sign.Content) (
 	// Steady state: sign with the cached cert, skipping Fulcio. Safe to
 	// run unlocked because certPEM is a local copy and the keypair /
 	// signingConfig / trustedMaterial fields are immutable after init.
-	bundle, err := cbundle.SignData(ctx, content, bs.keypair, "", certPEM, nil, bs.signingConfig, bs.trustedMaterial, cbundle.SignOptions{})
+	bundle, err := signData(ctx, content, bs.keypair, "", certPEM, nil, bs.signingConfig, bs.trustedMaterial, cbundle.SignOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("signing bundle: %w", err)
 	}

--- a/pkg/private/secant/bundlesign.go
+++ b/pkg/private/secant/bundlesign.go
@@ -53,9 +53,6 @@ const bundleSignMaxAttempts = 5
 // Exposed as a var so tests can shrink the delay.
 var bundleSignInitialBackoff = 500 * time.Millisecond
 
-// signData is cbundle.SignData, indirected so tests can inject failures.
-var signData = cbundle.SignData
-
 // BundleSigner holds the materials needed for the cosign v3 bundle signing path.
 // The ephemeral keypair is generated once and reused across all operations.
 // Fulcio certificates are cached and refreshed when nearing expiry.
@@ -64,6 +61,10 @@ type BundleSigner struct {
 	signingConfig   *root.SigningConfig
 	trustedMaterial root.TrustedMaterial
 	keypair         sign.Keypair
+
+	// signData is cbundle.SignData in production; a field so tests can
+	// inject signing outcomes without network access.
+	signData func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error)
 
 	mu      sync.Mutex
 	certPEM []byte            // Cached PEM-encoded Fulcio certificate
@@ -121,6 +122,7 @@ func NewBundleSigner(oidc fulcio.OIDCProvider, opts ...BundleSignerOption) (*Bun
 		signingConfig:   cfg.signingConfig,
 		trustedMaterial: cfg.trustedMaterial,
 		keypair:         keypair,
+		signData:        cbundle.SignData,
 	}, nil
 }
 
@@ -134,7 +136,7 @@ func (bs *BundleSigner) signWithIDToken(ctx context.Context, content sign.Conten
 		return nil, fmt.Errorf("retrieving ID token: %w", err)
 	}
 
-	bundleBytes, err := signData(ctx, content, bs.keypair, idToken, nil, nil, bs.signingConfig, bs.trustedMaterial, cbundle.SignOptions{})
+	bundleBytes, err := bs.signData(ctx, content, bs.keypair, idToken, nil, nil, bs.signingConfig, bs.trustedMaterial, cbundle.SignOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("signing bundle: %w", err)
 	}
@@ -186,6 +188,9 @@ func (bs *BundleSigner) certNeedsRefresh() bool {
 // (Fulcio, TSA, Rekor) surfaces wrapped, untyped errors, so everything except
 // context cancellation is treated as transient. Attempts are bounded, so
 // misclassifying a terminal error costs at most a few extra round trips.
+// A failed attempt caches nothing, so retries on the cert-refresh path repeat
+// the OIDC and Fulcio round trips; refreshes are rare relative to the cert
+// lifetime and attempts are bounded, so that amplification is accepted.
 func (bs *BundleSigner) SignContent(ctx context.Context, content sign.Content) ([]byte, error) {
 	backoff := bundleSignInitialBackoff
 	for attempt := 1; ; attempt++ {
@@ -240,7 +245,7 @@ func (bs *BundleSigner) signContentOnce(ctx context.Context, content sign.Conten
 	// Steady state: sign with the cached cert, skipping Fulcio. Safe to
 	// run unlocked because certPEM is a local copy and the keypair /
 	// signingConfig / trustedMaterial fields are immutable after init.
-	bundle, err := signData(ctx, content, bs.keypair, "", certPEM, nil, bs.signingConfig, bs.trustedMaterial, cbundle.SignOptions{})
+	bundle, err := bs.signData(ctx, content, bs.keypair, "", certPEM, nil, bs.signingConfig, bs.trustedMaterial, cbundle.SignOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("signing bundle: %w", err)
 	}

--- a/pkg/private/secant/bundlesign_test.go
+++ b/pkg/private/secant/bundlesign_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/fulcio"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
@@ -158,12 +159,16 @@ func (f *fakeOIDCProvider) Provide(context.Context, string) (string, error) {
 	return "fake-token", nil
 }
 
-// stubSignData replaces the signData seam for the duration of the test.
-func stubSignData(t *testing.T, fn func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error)) {
-	t.Helper()
-	prev := signData
-	signData = fn
-	t.Cleanup(func() { signData = prev })
+// newStubbedSigner returns a BundleSigner whose SignData calls are served by
+// fn, keyed only on the content being signed, so tests can drive the retry
+// loop without network access.
+func newStubbedSigner(oidc fulcio.OIDCProvider, fn func(content sign.Content) ([]byte, error)) *BundleSigner {
+	return &BundleSigner{
+		oidc: oidc,
+		signData: func(_ context.Context, content sign.Content, _ sign.Keypair, _ string, _, _ []byte, _ *root.SigningConfig, _ root.TrustedMaterial, _ cbundle.SignOptions) ([]byte, error) {
+			return fn(content)
+		},
+	}
 }
 
 func setBundleBackoff(t *testing.T, d time.Duration) {
@@ -217,15 +222,13 @@ func TestSignContentRetriesTransient(t *testing.T) {
 
 	transient := errors.New("stream error: INTERNAL_ERROR")
 	var attempts atomic.Int32
-	stubSignData(t, func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error) {
+	provider := &fakeOIDCProvider{}
+	bs := newStubbedSigner(provider, func(sign.Content) ([]byte, error) {
 		if attempts.Add(1) < 3 {
 			return nil, transient
 		}
 		return bundleJSON, nil
 	})
-
-	provider := &fakeOIDCProvider{}
-	bs := &BundleSigner{oidc: provider}
 
 	got, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: []byte("payload")})
 	if err != nil {
@@ -263,12 +266,10 @@ func TestSignContentExhaustsAttempts(t *testing.T) {
 
 	persistent := errors.New("persistent failure")
 	var attempts atomic.Int32
-	stubSignData(t, func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error) {
+	bs := newStubbedSigner(&fakeOIDCProvider{}, func(sign.Content) ([]byte, error) {
 		attempts.Add(1)
 		return nil, persistent
 	})
-
-	bs := &BundleSigner{oidc: &fakeOIDCProvider{}}
 	_, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: []byte("payload")})
 	if !errors.Is(err, persistent) {
 		t.Fatalf("err = %v, want %v", err, persistent)
@@ -279,21 +280,21 @@ func TestSignContentExhaustsAttempts(t *testing.T) {
 }
 
 func TestSignContentAbortsOnContextCancel(t *testing.T) {
-	// An hour of backoff fails the test by timeout if cancellation doesn't
-	// abort the retry loop.
+	// Covers cancellation detected right after a failed attempt: the loop
+	// must return without sleeping or retrying. Cancellation arriving
+	// mid-sleep is covered by TestSignContentCancelDuringBackoff.
 	setBundleBackoff(t, time.Hour)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var attempts atomic.Int32
-	stubSignData(t, func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error) {
+	bs := newStubbedSigner(&fakeOIDCProvider{}, func(sign.Content) ([]byte, error) {
 		attempts.Add(1)
 		cancel()
 		return nil, errors.New("boom")
 	})
 
-	bs := &BundleSigner{oidc: &fakeOIDCProvider{}}
 	if _, err := bs.SignContent(ctx, &sign.DSSEData{Data: []byte("payload")}); err == nil {
 		t.Fatal("expected error")
 	}
@@ -302,17 +303,57 @@ func TestSignContentAbortsOnContextCancel(t *testing.T) {
 	}
 }
 
+func TestSignContentCancelDuringBackoff(t *testing.T) {
+	// An hour of backoff plus the bounded wait below fails fast if
+	// cancellation can't interrupt the sleep between attempts.
+	setBundleBackoff(t, time.Hour)
+
+	firstFailure := make(chan struct{})
+	var once sync.Once
+	var attempts atomic.Int32
+	bs := newStubbedSigner(&fakeOIDCProvider{}, func(sign.Content) ([]byte, error) {
+		attempts.Add(1)
+		once.Do(func() { close(firstFailure) })
+		return nil, errors.New("boom")
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := bs.SignContent(ctx, &sign.DSSEData{Data: []byte("payload")})
+		done <- err
+	}()
+
+	<-firstFailure
+	// Give the goroutine time to get past the post-attempt ctx check and
+	// into the backoff sleep before cancelling.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("err = %v, want context.Canceled from the backoff sleep", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("SignContent did not return after cancellation; backoff sleep is not context-aware")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("attempts = %d, want 1", got)
+	}
+}
+
 func TestSignContentRateLimiterGatesFirstAttempt(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	var attempts atomic.Int32
-	stubSignData(t, func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error) {
+	bs := newStubbedSigner(&fakeOIDCProvider{}, func(sign.Content) ([]byte, error) {
 		attempts.Add(1)
 		return nil, errors.New("boom")
 	})
-
-	bs := &BundleSigner{oidc: &fakeOIDCProvider{}}
 	_, err := bs.SignContent(ctx, &sign.DSSEData{Data: []byte("payload")})
 	if err == nil || !strings.Contains(err.Error(), "waiting for bundle rate limiter") {
 		t.Fatalf("err = %v, want bundle rate limiter wait failure", err)
@@ -331,55 +372,75 @@ func TestSignContentNilRateLimiter(t *testing.T) {
 	derBlock, _ := pem.Decode(certPEM)
 	bundleJSON := buildTestBundleJSONCertificate(t, derBlock.Bytes)
 
-	stubSignData(t, func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error) {
+	bs := newStubbedSigner(&fakeOIDCProvider{}, func(sign.Content) ([]byte, error) {
 		return bundleJSON, nil
 	})
-
-	bs := &BundleSigner{oidc: &fakeOIDCProvider{}}
 	if _, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: []byte("payload")}); err != nil {
 		t.Fatalf("SignContent with nil rate limiter: %v", err)
 	}
 }
 
-func TestSignContentBackoffDoesNotBlockConcurrentSigns(t *testing.T) {
-	setBundleBackoff(t, 50*time.Millisecond)
+func TestSignContentBackoffDoesNotHoldMutex(t *testing.T) {
+	// Long enough that the retrying call sleeps for the whole probe phase;
+	// the cleanup cancels it rather than waiting the backoff out.
+	setBundleBackoff(t, time.Minute)
 
 	certPEM, cert := generateTestCert(t, 10*time.Minute)
 	derBlock, _ := pem.Decode(certPEM)
 	bundleJSON := buildTestBundleJSONCertificate(t, derBlock.Bytes)
 
-	// Seed the cert cache so both calls take the steady-state path.
-	bs := &BundleSigner{oidc: &fakeOIDCProvider{}, cert: cert, certPEM: certPEM}
-
 	failing := []byte("failing payload")
 	firstFailure := make(chan struct{})
 	var once sync.Once
-	stubSignData(t, func(_ context.Context, content sign.Content, _ sign.Keypair, _ string, _, _ []byte, _ *root.SigningConfig, _ root.TrustedMaterial, _ cbundle.SignOptions) ([]byte, error) {
+	bs := newStubbedSigner(&fakeOIDCProvider{}, func(content sign.Content) ([]byte, error) {
 		if dsse, ok := content.(*sign.DSSEData); ok && bytes.Equal(dsse.Data, failing) {
 			once.Do(func() { close(firstFailure) })
 			return nil, errors.New("boom")
 		}
 		return bundleJSON, nil
 	})
+	// Seed the cert cache so both calls take the steady-state path.
+	bs.cert = cert
+	bs.certPEM = certPEM
 
+	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
 	go func() {
-		_, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: failing})
+		_, err := bs.SignContent(ctx, &sign.DSSEData{Data: failing})
 		done <- err
 	}()
+	// Join the retrying goroutine on every exit path, including t.Fatal,
+	// before earlier-registered cleanups restore shared test state.
+	t.Cleanup(func() {
+		cancel()
+		if err := <-done; err == nil {
+			t.Error("expected the failing call to return an error")
+		}
+	})
 
-	// While the failing call backs off between attempts, a healthy sign on
-	// the cached-cert path must proceed rather than queue behind it.
 	<-firstFailure
+	// While the failing call sleeps between attempts, the signer mutex must
+	// stay free. Probe repeatedly so a lock held for even part of the
+	// backoff window is caught, not just one held across the whole loop.
+	for range 10 {
+		acquired := false
+		for start := time.Now(); time.Since(start) < 100*time.Millisecond; {
+			if bs.mu.TryLock() {
+				bs.mu.Unlock()
+				acquired = true
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+		if !acquired {
+			t.Fatal("signer mutex unavailable during backoff; the retry loop appears to hold it while sleeping")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// A healthy sign on the cached-cert path must also complete while the
+	// other call is still backing off.
 	if _, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: []byte("healthy payload")}); err != nil {
 		t.Fatalf("concurrent SignContent: %v", err)
-	}
-	select {
-	case <-done:
-		t.Error("retrying call finished before the concurrent sign; backoff appears to serialize signs")
-	default:
-	}
-	if err := <-done; err == nil {
-		t.Error("expected the failing call to return an error")
 	}
 }

--- a/pkg/private/secant/bundlesign_test.go
+++ b/pkg/private/secant/bundlesign_test.go
@@ -1,18 +1,29 @@
 package secant
 
 import (
+	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore-go/pkg/sign"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -133,4 +144,242 @@ func buildTestBundleJSONCertificate(t *testing.T, certDER []byte) []byte {
 		t.Fatalf("marshaling test bundle: %v", err)
 	}
 	return data
+}
+
+// fakeOIDCProvider implements fulcio.OIDCProvider with a canned token.
+type fakeOIDCProvider struct {
+	calls atomic.Int32
+}
+
+func (f *fakeOIDCProvider) Enabled(context.Context) bool { return true }
+
+func (f *fakeOIDCProvider) Provide(context.Context, string) (string, error) {
+	f.calls.Add(1)
+	return "fake-token", nil
+}
+
+// stubSignData replaces the signData seam for the duration of the test.
+func stubSignData(t *testing.T, fn func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error)) {
+	t.Helper()
+	prev := signData
+	signData = fn
+	t.Cleanup(func() { signData = prev })
+}
+
+func setBundleBackoff(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := bundleSignInitialBackoff
+	bundleSignInitialBackoff = d
+	t.Cleanup(func() { bundleSignInitialBackoff = prev })
+}
+
+// counterValue returns the current value of a prometheus counter.
+func counterValue(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	if err := c.Write(&m); err != nil {
+		t.Fatalf("writing metric: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+// bundleWaitSampleCount returns how many waits the bundle rate limiter has
+// recorded, read through reg because the histogram lives unexported in the
+// tlog package.
+func bundleWaitSampleCount(t *testing.T, reg *prometheus.Registry) uint64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gathering metrics: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == "secant_bundle_rate_limiter_wait_duration_seconds" {
+			return mf.GetMetric()[0].GetHistogram().GetSampleCount()
+		}
+	}
+	t.Fatal("bundle rate limiter histogram not registered")
+	return 0
+}
+
+func TestSignContentRetriesTransient(t *testing.T) {
+	setBundleBackoff(t, time.Millisecond)
+
+	reg := prometheus.NewRegistry()
+	if err := RegisterMetrics(reg); err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+	retriesBefore := counterValue(t, bundleSignRetries)
+	waitsBefore := bundleWaitSampleCount(t, reg)
+
+	certPEM, _ := generateTestCert(t, 10*time.Minute)
+	derBlock, _ := pem.Decode(certPEM)
+	bundleJSON := buildTestBundleJSONCertificate(t, derBlock.Bytes)
+
+	transient := errors.New("stream error: INTERNAL_ERROR")
+	var attempts atomic.Int32
+	stubSignData(t, func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error) {
+		if attempts.Add(1) < 3 {
+			return nil, transient
+		}
+		return bundleJSON, nil
+	})
+
+	provider := &fakeOIDCProvider{}
+	bs := &BundleSigner{oidc: provider}
+
+	got, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: []byte("payload")})
+	if err != nil {
+		t.Fatalf("SignContent: %v", err)
+	}
+	if !bytes.Equal(got, bundleJSON) {
+		t.Error("SignContent returned unexpected bundle bytes")
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("attempts = %d, want 3", got)
+	}
+	if got := counterValue(t, bundleSignRetries) - retriesBefore; got != 2 {
+		t.Errorf("recorded %v retries, want 2", got)
+	}
+	// One rate limiter token per attempt, including the first.
+	if got, want := bundleWaitSampleCount(t, reg)-waitsBefore, uint64(3); got != want {
+		t.Errorf("recorded %d rate limiter waits, want %d", got, want)
+	}
+
+	// The successful attempt cached the cert, so a subsequent call takes the
+	// steady-state path without another OIDC round-trip.
+	if got := provider.calls.Load(); got != 3 {
+		t.Errorf("provider calls = %d, want 3 (one per refresh-path attempt)", got)
+	}
+	if _, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: []byte("payload")}); err != nil {
+		t.Fatalf("SignContent with cached cert: %v", err)
+	}
+	if got := provider.calls.Load(); got != 3 {
+		t.Errorf("provider calls after cached-cert sign = %d, want 3", got)
+	}
+}
+
+func TestSignContentExhaustsAttempts(t *testing.T) {
+	setBundleBackoff(t, time.Millisecond)
+
+	persistent := errors.New("persistent failure")
+	var attempts atomic.Int32
+	stubSignData(t, func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error) {
+		attempts.Add(1)
+		return nil, persistent
+	})
+
+	bs := &BundleSigner{oidc: &fakeOIDCProvider{}}
+	_, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: []byte("payload")})
+	if !errors.Is(err, persistent) {
+		t.Fatalf("err = %v, want %v", err, persistent)
+	}
+	if got := attempts.Load(); got != bundleSignMaxAttempts {
+		t.Errorf("attempts = %d, want %d", got, bundleSignMaxAttempts)
+	}
+}
+
+func TestSignContentAbortsOnContextCancel(t *testing.T) {
+	// An hour of backoff fails the test by timeout if cancellation doesn't
+	// abort the retry loop.
+	setBundleBackoff(t, time.Hour)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var attempts atomic.Int32
+	stubSignData(t, func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error) {
+		attempts.Add(1)
+		cancel()
+		return nil, errors.New("boom")
+	})
+
+	bs := &BundleSigner{oidc: &fakeOIDCProvider{}}
+	if _, err := bs.SignContent(ctx, &sign.DSSEData{Data: []byte("payload")}); err == nil {
+		t.Fatal("expected error")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("attempts = %d, want 1 (should abort before second attempt)", got)
+	}
+}
+
+func TestSignContentRateLimiterGatesFirstAttempt(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var attempts atomic.Int32
+	stubSignData(t, func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error) {
+		attempts.Add(1)
+		return nil, errors.New("boom")
+	})
+
+	bs := &BundleSigner{oidc: &fakeOIDCProvider{}}
+	_, err := bs.SignContent(ctx, &sign.DSSEData{Data: []byte("payload")})
+	if err == nil || !strings.Contains(err.Error(), "waiting for bundle rate limiter") {
+		t.Fatalf("err = %v, want bundle rate limiter wait failure", err)
+	}
+	if got := attempts.Load(); got != 0 {
+		t.Errorf("attempts = %d, want 0 (limiter should gate the first attempt)", got)
+	}
+}
+
+func TestSignContentNilRateLimiter(t *testing.T) {
+	prev := BundleRateLimiter
+	BundleRateLimiter = nil
+	t.Cleanup(func() { BundleRateLimiter = prev })
+
+	certPEM, _ := generateTestCert(t, 10*time.Minute)
+	derBlock, _ := pem.Decode(certPEM)
+	bundleJSON := buildTestBundleJSONCertificate(t, derBlock.Bytes)
+
+	stubSignData(t, func(context.Context, sign.Content, sign.Keypair, string, []byte, []byte, *root.SigningConfig, root.TrustedMaterial, cbundle.SignOptions) ([]byte, error) {
+		return bundleJSON, nil
+	})
+
+	bs := &BundleSigner{oidc: &fakeOIDCProvider{}}
+	if _, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: []byte("payload")}); err != nil {
+		t.Fatalf("SignContent with nil rate limiter: %v", err)
+	}
+}
+
+func TestSignContentBackoffDoesNotBlockConcurrentSigns(t *testing.T) {
+	setBundleBackoff(t, 50*time.Millisecond)
+
+	certPEM, cert := generateTestCert(t, 10*time.Minute)
+	derBlock, _ := pem.Decode(certPEM)
+	bundleJSON := buildTestBundleJSONCertificate(t, derBlock.Bytes)
+
+	// Seed the cert cache so both calls take the steady-state path.
+	bs := &BundleSigner{oidc: &fakeOIDCProvider{}, cert: cert, certPEM: certPEM}
+
+	failing := []byte("failing payload")
+	firstFailure := make(chan struct{})
+	var once sync.Once
+	stubSignData(t, func(_ context.Context, content sign.Content, _ sign.Keypair, _ string, _, _ []byte, _ *root.SigningConfig, _ root.TrustedMaterial, _ cbundle.SignOptions) ([]byte, error) {
+		if dsse, ok := content.(*sign.DSSEData); ok && bytes.Equal(dsse.Data, failing) {
+			once.Do(func() { close(firstFailure) })
+			return nil, errors.New("boom")
+		}
+		return bundleJSON, nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: failing})
+		done <- err
+	}()
+
+	// While the failing call backs off between attempts, a healthy sign on
+	// the cached-cert path must proceed rather than queue behind it.
+	<-firstFailure
+	if _, err := bs.SignContent(t.Context(), &sign.DSSEData{Data: []byte("healthy payload")}); err != nil {
+		t.Fatalf("concurrent SignContent: %v", err)
+	}
+	select {
+	case <-done:
+		t.Error("retrying call finished before the concurrent sign; backoff appears to serialize signs")
+	default:
+	}
+	if err := <-done; err == nil {
+		t.Error("expected the failing call to return an error")
+	}
 }

--- a/pkg/private/secant/tlog/tlog.go
+++ b/pkg/private/secant/tlog/tlog.go
@@ -58,7 +58,9 @@ var (
 )
 
 // RegisterMetrics registers the tlog collectors with r. Hosts that scrape
-// metrics call this once; the Terraform provider never does.
+// metrics should call the parent secant package's RegisterMetrics instead,
+// which includes these collectors along with secant's own; the Terraform
+// provider calls neither.
 func RegisterMetrics(r prometheus.Registerer) error {
 	for _, c := range []prometheus.Collector{rekorWaitSeconds, bundleWaitSeconds} {
 		if err := r.Register(c); err != nil {

--- a/pkg/private/secant/tlog/tlog.go
+++ b/pkg/private/secant/tlog/tlog.go
@@ -32,39 +32,70 @@ import (
 // RekorRateLimiter throttles all calls to Rekor (including retries from
 // createLogEntryWithRetry) to stay within rate limits. Defaults to 5 QPS with
 // a burst of 50.
-var RekorRateLimiter = &RateLimiter{limiter: rate.NewLimiter(5.0, 50)}
+var RekorRateLimiter = &RateLimiter{limiter: rate.NewLimiter(5.0, 50), waitSeconds: rekorWaitSeconds}
 
-// rekorWaitSeconds is left unregistered so only hosts that opt in via
-// RegisterMetrics gather it.
-var rekorWaitSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
-	Name:    "secant_rekor_rate_limiter_wait_duration_seconds",
-	Help:    "Seconds spent blocked acquiring tokens from the Rekor rate limiter.",
-	Buckets: prometheus.ExponentialBuckets(0.001, 3, 12),
-})
+// BundleRateLimiter throttles bundle signing attempts (the Fulcio/Rekor v2/TSA
+// chain behind BundleSigner.SignContent), including retries. It is a separate
+// instance from RekorRateLimiter because the bundle path writes to a different
+// backend (Rekor v2): sharing one budget would let either path starve the
+// other, and dual-writing hosts would pay double tokens per image. Defaults
+// mirror RekorRateLimiter; use SetLimit/SetBurst to tune.
+var BundleRateLimiter = &RateLimiter{limiter: rate.NewLimiter(5.0, 50), waitSeconds: bundleWaitSeconds}
+
+// rekorWaitSeconds and bundleWaitSeconds are left unregistered so only hosts
+// that opt in via RegisterMetrics gather them.
+var (
+	rekorWaitSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "secant_rekor_rate_limiter_wait_duration_seconds",
+		Help:    "Seconds spent blocked acquiring tokens from the Rekor rate limiter.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 3, 12),
+	})
+	bundleWaitSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "secant_bundle_rate_limiter_wait_duration_seconds",
+		Help:    "Seconds spent blocked acquiring tokens from the bundle signing rate limiter.",
+		Buckets: prometheus.ExponentialBuckets(0.001, 3, 12),
+	})
+)
 
 // RegisterMetrics registers the tlog collectors with r. Hosts that scrape
 // metrics call this once; the Terraform provider never does.
 func RegisterMetrics(r prometheus.Registerer) error {
-	return r.Register(rekorWaitSeconds)
+	for _, c := range []prometheus.Collector{rekorWaitSeconds, bundleWaitSeconds} {
+		if err := r.Register(c); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // RateLimiter throttles acquires and records how long each one blocks.
 type RateLimiter struct {
-	limiter *rate.Limiter
+	limiter     *rate.Limiter
+	waitSeconds prometheus.Histogram // nil means waits go unobserved
 }
 
 func (r *RateLimiter) Wait(ctx context.Context) error {
-	start := time.Now()
-	err := r.limiter.Wait(ctx)
-	rekorWaitSeconds.Observe(time.Since(start).Seconds())
-	return err
+	return r.WaitN(ctx, 1)
 }
 
 func (r *RateLimiter) WaitN(ctx context.Context, n int) error {
 	start := time.Now()
 	err := r.limiter.WaitN(ctx, n)
-	rekorWaitSeconds.Observe(time.Since(start).Seconds())
+	if r.waitSeconds != nil {
+		r.waitSeconds.Observe(time.Since(start).Seconds())
+	}
 	return err
+}
+
+// SetLimit updates the sustained rate to qps tokens per second, so hosts can
+// tune a limiter without reconstructing it.
+func (r *RateLimiter) SetLimit(qps float64) {
+	r.limiter.SetLimit(rate.Limit(qps))
+}
+
+// SetBurst updates the burst size.
+func (r *RateLimiter) SetBurst(n int) {
+	r.limiter.SetBurst(n)
 }
 
 const createLogEntryMaxAttempts = 5

--- a/pkg/private/secant/tlog/tlog_test.go
+++ b/pkg/private/secant/tlog/tlog_test.go
@@ -11,11 +11,66 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
+	"golang.org/x/time/rate"
 )
 
 func TestRegisterMetrics(t *testing.T) {
-	if err := RegisterMetrics(prometheus.NewRegistry()); err != nil {
+	reg := prometheus.NewRegistry()
+	if err := RegisterMetrics(reg); err != nil {
 		t.Fatalf("RegisterMetrics: %v", err)
+	}
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gathering: %v", err)
+	}
+	got := make(map[string]bool, len(mfs))
+	for _, mf := range mfs {
+		got[mf.GetName()] = true
+	}
+	for _, want := range []string{
+		"secant_rekor_rate_limiter_wait_duration_seconds",
+		"secant_bundle_rate_limiter_wait_duration_seconds",
+	} {
+		if !got[want] {
+			t.Errorf("metric %q not registered", want)
+		}
+	}
+}
+
+func TestRateLimiterObservesWaits(t *testing.T) {
+	h := prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_rate_limiter_wait_seconds"})
+	rl := &RateLimiter{limiter: rate.NewLimiter(rate.Inf, 1), waitSeconds: h}
+	if err := rl.Wait(t.Context()); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if err := rl.WaitN(t.Context(), 1); err != nil {
+		t.Fatalf("WaitN: %v", err)
+	}
+	var m dto.Metric
+	if err := h.Write(&m); err != nil {
+		t.Fatalf("writing metric: %v", err)
+	}
+	if got := m.GetHistogram().GetSampleCount(); got != 2 {
+		t.Errorf("recorded %d observations, want 2", got)
+	}
+}
+
+func TestRateLimiterNilHistogram(t *testing.T) {
+	rl := &RateLimiter{limiter: rate.NewLimiter(rate.Inf, 1)}
+	if err := rl.Wait(t.Context()); err != nil {
+		t.Fatalf("Wait with nil histogram: %v", err)
+	}
+}
+
+func TestRateLimiterSetLimitSetBurst(t *testing.T) {
+	rl := &RateLimiter{limiter: rate.NewLimiter(1, 1)}
+	rl.SetLimit(10)
+	rl.SetBurst(20)
+	if got := rl.limiter.Limit(); got != 10 {
+		t.Errorf("Limit() = %v, want 10", got)
+	}
+	if got := rl.limiter.Burst(); got != 20 {
+		t.Errorf("Burst() = %v, want 20", got)
 	}
 }
 


### PR DESCRIPTION
The cosign v3 bundle signing path (`BundleSigner.SignContent` → Fulcio/Rekor v2/TSA) has no retry or throttling — cosign hardcodes a single attempt internally and `SignOptions` exposes no knobs — while the legacy Rekor v1 path has both (`RekorRateLimiter`, `createLogEntryWithRetry`). Consumers that treat bundle writes as best-effort silently lose signatures to transient errors until their next reconcile.

This PR gives the bundle path the same durability discipline: one rate-limiter token per signing attempt and bounded exponential-backoff retries, placed at the `SignContent` seam so SkipSame short-circuits still skip everything and steady-state no-op reconciles pay nothing.

Key changes:
- **Retry loop in `SignContent`**: 5 attempts with 500ms doubling backoff, mirroring the legacy `createLogEntryWithRetry`; each attempt acquires the signer mutex independently, so backoff sleeps never block concurrent cached-cert signs.
- **`BundleRateLimiter`** (5 QPS / burst 50): a separate budget from `RekorRateLimiter` because Rekor v1 and v2 are different backends — sharing one would let either path starve the other, and dual-writing hosts would pay double per image. Nil disables it.
- **Coarse error classification**: everything except context cancellation retries; the sigstore-go chain surfaces wrapped untyped errors, and bounded attempts cap the cost of retrying a terminal one.
- **Parameterized limiter metrics**: `RateLimiter` now carries its wait histogram as a field so the two instances don't conflate observations, and grows `SetLimit`/`SetBurst` so operators can tune without reconstructing.
- **New collectors**: `secant_bundle_rate_limiter_wait_duration_seconds` and `secant_bundle_sign_retries_total`, unregistered by default and picked up through the existing `RegisterMetrics` entrypoint.
- **Tests**: the retry contract runs offline via a `signData` seam — transient-then-success with attempt/token accounting, exhaustion, context cancellation, limiter gating, nil-limiter opt-out, and a race-detector concurrency test proving backoff doesn't serialize signs.

Assisted by Claude Fable 5