### PR TITLE
fix(secant): SignBundle signs index children like legacy Sign

### DIFF
--- a/pkg/private/secant/bundlesign.go
+++ b/pkg/private/secant/bundlesign.go
@@ -164,6 +164,16 @@ func (bs *BundleSigner) certNeedsRefresh() bool {
 // internally. The cert is extracted from the bundle and cached so that
 // subsequent calls pass it directly, skipping Fulcio entirely.
 func (bs *BundleSigner) SignContent(ctx context.Context, content sign.Content) ([]byte, error) {
+	// Every SignContent ends in one transparency-log upload, and the
+	// Rekor v2 write client does not retry a 429 — gate it through the
+	// same limiter as the legacy paths. Wait before taking the mutex so
+	// a throttled caller doesn't block concurrent cached-cert signs.
+	if RekorRateLimiter != nil {
+		if err := RekorRateLimiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("waiting for rekor rate limiter: %w", err)
+		}
+	}
+
 	// Lock scope is deliberately split: we hold the mutex across a cert
 	// refresh so concurrent callers coalesce onto a single Fulcio fetch,
 	// but release it before the steady-state sign so cached-cert signs
@@ -222,12 +232,7 @@ func signBundle(ctx context.Context, conflict string, annotations map[string]any
 		}
 
 		if err := walk.SignedEntity(ctx, se, func(ctx context.Context, se oci.SignedEntity) error {
-			// Get the digest for this entity in our walk.
-			digestable, ok := se.(interface{ Digest() (v1.Hash, error) })
-			if !ok {
-				return fmt.Errorf("entity does not implement Digest() method")
-			}
-			d, err := digestable.Digest()
+			d, err := se.Digest()
 			if err != nil {
 				return fmt.Errorf("computing digest: %w", err)
 			}

--- a/pkg/private/secant/bundlesign.go
+++ b/pkg/private/secant/bundlesign.go
@@ -24,7 +24,9 @@ import (
 	intotov1 "github.com/in-toto/attestation/go/v1"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
+	"github.com/sigstore/cosign/v3/pkg/oci"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+	"github.com/sigstore/cosign/v3/pkg/oci/walk"
 	ctypes "github.com/sigstore/cosign/v3/pkg/types"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	"github.com/sigstore/sigstore-go/pkg/root"
@@ -192,62 +194,101 @@ func (bs *BundleSigner) SignContent(ctx context.Context, content sign.Content) (
 	return bundle, nil
 }
 
+// contentSigner is the part of BundleSigner that SignBundle consumes — the
+// seam that lets tests drive the walk and write fan-out without Fulcio.
+type contentSigner interface {
+	SignContent(ctx context.Context, content sign.Content) ([]byte, error)
+}
+
 // SignBundle signs container images using the cosign v3 bundle format
-// and writes them as OCI referrers. conflict matches the semantics of Sign:
-// APPEND (or empty) always writes, SKIPSAME skips when an existing referrer
-// has an identical payload, REPLACE deletes existing referrers with matching
-// predicate type before writing.
+// and writes them as OCI referrers. Like the legacy Sign, it signs each
+// image and its constituent manifests transitively: an image index and every
+// child manifest each get their own sign-predicate bundle referrer, so
+// arch-pinned digests verify the same as the index. conflict matches the
+// semantics of Sign: APPEND (or empty) always writes, SKIPSAME skips when an
+// existing referrer has an identical payload, REPLACE deletes existing
+// referrers with matching predicate type before writing.
 func SignBundle(ctx context.Context, conflict string, annotations map[string]any, signer *BundleSigner, imgs []name.Digest, ropt []remote.Option) error {
+	return signBundle(ctx, conflict, annotations, signer, imgs, ropt)
+}
+
+func signBundle(ctx context.Context, conflict string, annotations map[string]any, signer contentSigner, imgs []name.Digest, ropt []remote.Option) error {
 	opts := []ociremote.Option{ociremote.WithRemoteOptions(ropt...)}
 
-	for _, digest := range imgs {
-		digestParts := strings.Split(digest.DigestStr(), ":")
-		if len(digestParts) != 2 {
-			return fmt.Errorf("unable to parse digest %s", digest.DigestStr())
-		}
-
-		annoStruct, err := structpb.NewStruct(annotations)
+	for _, ref := range imgs {
+		se, err := ociremote.SignedEntity(ref, opts...)
 		if err != nil {
-			return fmt.Errorf("converting annotations to protobuf struct: %w", err)
-		}
-		subject := intotov1.ResourceDescriptor{
-			Digest:      map[string]string{digestParts[0]: digestParts[1]},
-			Annotations: annoStruct,
+			return fmt.Errorf("accessing entity: %w", err)
 		}
 
-		statement := &intotov1.Statement{
-			Type:          intotov1.StatementTypeUri,
-			Subject:       []*intotov1.ResourceDescriptor{&subject},
-			PredicateType: ctypes.CosignSignPredicateType,
-			Predicate:     &structpb.Struct{},
+		if err := walk.SignedEntity(ctx, se, func(ctx context.Context, se oci.SignedEntity) error {
+			// Get the digest for this entity in our walk.
+			digestable, ok := se.(interface{ Digest() (v1.Hash, error) })
+			if !ok {
+				return fmt.Errorf("entity does not implement Digest() method")
+			}
+			d, err := digestable.Digest()
+			if err != nil {
+				return fmt.Errorf("computing digest: %w", err)
+			}
+			return signBundleDigest(ctx, conflict, annotations, signer, ref.Context().Digest(d.String()), ropt, opts)
+		}); err != nil {
+			return fmt.Errorf("recursively signing: %w", err)
 		}
+	}
 
-		payload, err := protojson.Marshal(statement)
-		if err != nil {
-			return fmt.Errorf("marshaling statement: %w", err)
-		}
+	return nil
+}
 
-		shouldWrite, err := resolveBundleConflict(digest, ctypes.CosignSignPredicateType, payload, conflict, ropt, opts)
-		if err != nil {
-			return fmt.Errorf("resolving conflict for %q: %w", digest.String(), err)
-		}
-		if !shouldWrite {
-			continue
-		}
+// signBundleDigest signs exactly one digest with a sign-predicate bundle,
+// applying the conflict policy against its existing referrers.
+func signBundleDigest(ctx context.Context, conflict string, annotations map[string]any, signer contentSigner, digest name.Digest, ropt []remote.Option, opts []ociremote.Option) error {
+	digestParts := strings.Split(digest.DigestStr(), ":")
+	if len(digestParts) != 2 {
+		return fmt.Errorf("unable to parse digest %s", digest.DigestStr())
+	}
 
-		content := &sign.DSSEData{
-			Data:        payload,
-			PayloadType: ctypes.IntotoPayloadType,
-		}
+	annoStruct, err := structpb.NewStruct(annotations)
+	if err != nil {
+		return fmt.Errorf("converting annotations to protobuf struct: %w", err)
+	}
+	subject := intotov1.ResourceDescriptor{
+		Digest:      map[string]string{digestParts[0]: digestParts[1]},
+		Annotations: annoStruct,
+	}
 
-		bundleBytes, err := signer.SignContent(ctx, content)
-		if err != nil {
-			return fmt.Errorf("signing bundle for %q: %w", digest.String(), err)
-		}
+	statement := &intotov1.Statement{
+		Type:          intotov1.StatementTypeUri,
+		Subject:       []*intotov1.ResourceDescriptor{&subject},
+		PredicateType: ctypes.CosignSignPredicateType,
+		Predicate:     &structpb.Struct{},
+	}
 
-		if err := writeBundleReferrer(digest, bundleBytes, ctypes.CosignSignPredicateType, nil, ropt); err != nil {
-			return fmt.Errorf("writing sign bundle for %q: %w", digest.String(), err)
-		}
+	payload, err := protojson.Marshal(statement)
+	if err != nil {
+		return fmt.Errorf("marshaling statement: %w", err)
+	}
+
+	shouldWrite, err := resolveBundleConflict(digest, ctypes.CosignSignPredicateType, payload, conflict, ropt, opts)
+	if err != nil {
+		return fmt.Errorf("resolving conflict for %q: %w", digest.String(), err)
+	}
+	if !shouldWrite {
+		return nil
+	}
+
+	content := &sign.DSSEData{
+		Data:        payload,
+		PayloadType: ctypes.IntotoPayloadType,
+	}
+
+	bundleBytes, err := signer.SignContent(ctx, content)
+	if err != nil {
+		return fmt.Errorf("signing bundle for %q: %w", digest.String(), err)
+	}
+
+	if err := writeBundleReferrer(digest, bundleBytes, ctypes.CosignSignPredicateType, nil, ropt); err != nil {
+		return fmt.Errorf("writing sign bundle for %q: %w", digest.String(), err)
 	}
 
 	return nil

--- a/pkg/private/secant/bundlesign_test.go
+++ b/pkg/private/secant/bundlesign_test.go
@@ -161,9 +161,7 @@ func (f *fakeContentSigner) SignContent(_ context.Context, content sign.Content)
 
 // TestSignBundleWalksIndexChildren mirrors TestSign for the bundle path: the
 // walk must attach a sign-predicate bundle to the index and to each child
-// manifest, each bundle's statement naming that entity as its subject. Before
-// the walk, only the index was signed, leaving arch-pinned digests of a
-// bundle-only image unverifiable (CON-2628).
+// manifest, each bundle's statement naming that entity as its subject.
 func TestSignBundleWalksIndexChildren(t *testing.T) {
 	ctx := context.Background()
 
@@ -232,6 +230,22 @@ func TestSignBundleWalksIndexChildren(t *testing.T) {
 			for _, d := range digests {
 				if got := len(signBundleStatements(t, d)); got != 1 {
 					t.Errorf("got %d sign bundles for %s after re-run, want 1", got, d)
+				}
+			}
+
+			// A REPLACE run re-signs every walked entity — pinning that the
+			// caller's conflict mode reaches the per-digest path — and still
+			// converges on one bundle per digest.
+			signer.calls = 0
+			if err := signBundle(ctx, Replace, nil, signer, digests[:1], nil); err != nil {
+				t.Fatalf("signBundle() REPLACE = %v", err)
+			}
+			if signer.calls != len(digests) {
+				t.Errorf("REPLACE run performed %d sign operations, want %d", signer.calls, len(digests))
+			}
+			for _, d := range digests {
+				if got := len(signBundleStatements(t, d)); got != 1 {
+					t.Errorf("got %d sign bundles for %s after REPLACE, want 1", got, d)
 				}
 			}
 		})

--- a/pkg/private/secant/bundlesign_test.go
+++ b/pkg/private/secant/bundlesign_test.go
@@ -1,18 +1,26 @@
 package secant
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	intotov1 "github.com/in-toto/attestation/go/v1"
+	ctypes "github.com/sigstore/cosign/v3/pkg/types"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore-go/pkg/sign"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -133,4 +141,119 @@ func buildTestBundleJSONCertificate(t *testing.T, certDER []byte) []byte {
 		t.Fatalf("marshaling test bundle: %v", err)
 	}
 	return data
+}
+
+// fakeContentSigner stands in for BundleSigner: it wraps each DSSE payload it
+// is asked to sign in a minimal bundle and counts invocations.
+type fakeContentSigner struct {
+	t     *testing.T
+	calls int
+}
+
+func (f *fakeContentSigner) SignContent(_ context.Context, content sign.Content) ([]byte, error) {
+	f.calls++
+	dsse, ok := content.(*sign.DSSEData)
+	if !ok {
+		f.t.Fatalf("SignContent() got content type %T, want *sign.DSSEData", content)
+	}
+	return bundleWithDSSEPayload(f.t, dsse.Data), nil
+}
+
+// TestSignBundleWalksIndexChildren mirrors TestSign for the bundle path: the
+// walk must attach a sign-predicate bundle to the index and to each child
+// manifest, each bundle's statement naming that entity as its subject. Before
+// the walk, only the index was signed, leaving arch-pinned digests of a
+// bundle-only image unverifiable (CON-2628).
+func TestSignBundleWalksIndexChildren(t *testing.T) {
+	ctx := context.Background()
+
+	for _, referrersSupport := range []bool{true, false} {
+		t.Run(fmt.Sprintf("referrersSupport=%t", referrersSupport), func(t *testing.T) {
+			repo := newTestRepo(t, referrersSupport)
+
+			idx, err := random.Index(1024, 1, 2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := remote.WriteIndex(repo.Tag("latest"), idx); err != nil {
+				t.Fatal(err)
+			}
+
+			im, err := idx.IndexManifest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			h, err := idx.Digest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			digests := []name.Digest{repo.Digest(h.String())}
+			for _, m := range im.Manifests {
+				digests = append(digests, repo.Digest(m.Digest.String()))
+			}
+
+			signer := &fakeContentSigner{t: t}
+			if err := signBundle(ctx, SkipSame, nil, signer, digests[:1], nil); err != nil {
+				t.Fatalf("signBundle() = %v", err)
+			}
+
+			// The walk signs the index and each of its children, and every
+			// bundle's statement names the entity it is attached to.
+			for _, d := range digests {
+				statements := signBundleStatements(t, d)
+				if len(statements) != 1 {
+					t.Errorf("got %d sign bundles for %s, want 1", len(statements), d)
+					continue
+				}
+				statement := &intotov1.Statement{}
+				if err := protojson.Unmarshal(statements[0], statement); err != nil {
+					t.Fatalf("unmarshaling statement for %s: %v", d, err)
+				}
+				if got := len(statement.Subject); got != 1 {
+					t.Fatalf("got %d statement subjects for %s, want 1", got, d)
+				}
+				if got, want := "sha256:"+statement.Subject[0].Digest["sha256"], d.DigestStr(); got != want {
+					t.Errorf("statement subject = %s, want %s", got, want)
+				}
+			}
+			if signer.calls != len(digests) {
+				t.Errorf("got %d sign operations, want %d", signer.calls, len(digests))
+			}
+
+			// A SKIPSAME re-run finds every bundle already in place and signs
+			// nothing.
+			signer.calls = 0
+			if err := signBundle(ctx, SkipSame, nil, signer, digests[:1], nil); err != nil {
+				t.Fatalf("signBundle() re-run = %v", err)
+			}
+			if signer.calls != 0 {
+				t.Errorf("re-run performed %d sign operations, want 0", signer.calls)
+			}
+			for _, d := range digests {
+				if got := len(signBundleStatements(t, d)); got != 1 {
+					t.Errorf("got %d sign bundles for %s after re-run, want 1", got, d)
+				}
+			}
+		})
+	}
+}
+
+// signBundleStatements returns the DSSE statement payload of each
+// sign-predicate bundle referrer attached to d.
+func signBundleStatements(t *testing.T, d name.Digest) [][]byte {
+	t.Helper()
+
+	matching, err := matchingBundleReferrers(d, ctypes.CosignSignPredicateType, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payloads := make([][]byte, 0, len(matching))
+	for _, m := range matching {
+		p, err := referrerDSSEPayload(d.Repository, m.Digest, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payloads = append(payloads, p)
+	}
+	return payloads
 }


### PR DESCRIPTION
The legacy signing path (`secant.Sign`) walks the signed entity and signs the image index and every child manifest — legacy-signed images carry a per-arch `.sig` for each architecture. The bundle path (`secant.SignBundle`) signed only the digests it was handed, in practice just the index, so a bundle-only publish left per-arch child manifests with no signature of any kind: arch-pinned digests don't verify, and verifiers that walk the index and require a signature on every manifest reject the whole image (this is what blocked bundle-only images from syncing in CON-2628).

This makes SignBundle resolve the signed entity and walk it exactly like Sign, emitting one sign-predicate bundle referrer per manifest.

Key changes:
- **Walk in SignBundle**: resolve the entity via `ociremote.SignedEntity` + `walk.SignedEntity` over the index and its children, mirroring legacy `Sign`; the per-digest statement/conflict/write logic moves unchanged into `signBundleDigest`.
- **`contentSigner` seam**: the per-digest path consumes a minimal interface over `BundleSigner.SignContent` so tests can drive the walk without Fulcio.
- **Test**: `TestSignBundleWalksIndexChildren` mirrors legacy `TestSign` — a 2-arch index gets exactly one sign bundle per manifest, each statement naming its entity as subject, on both native-referrers and fallback-tag registries; a SKIPSAME re-run performs zero sign operations.

Behavior note: SignBundle now fetches the subject manifest (like Sign), so the image must exist in the registry before signing.

Assisted by Claude Fable 5