### PR TITLE
Bump Go to 1.27.0 and golangci-lint to v2.13

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,4 +48,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12
+          version: v2.13

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainguard-dev/terraform-provider-cosign
 
-go 1.26.4
+go 1.27.0
 
 require (
 	github.com/chainguard-dev/terraform-provider-oci v0.1.11

--- a/pkg/private/secant/tlog/tlog.go
+++ b/pkg/private/secant/tlog/tlog.go
@@ -80,8 +80,7 @@ func Upload(ctx context.Context, rekorClient *client.Rekor, pe models.ProposedEn
 	})
 	if err != nil {
 		// If the entry already exists, we get a specific error.
-		var existsErr *entries.CreateLogEntryConflict
-		if errors.As(err, &existsErr) {
+		if existsErr, ok := errors.AsType[*entries.CreateLogEntryConflict](err); ok {
 			fmt.Fprintln(os.Stderr, "Signature already exists.")
 			uriSplit := strings.Split(existsErr.Location.String(), "/")
 			uuid := uriSplit[len(uriSplit)-1]


### PR DESCRIPTION
golangci-lint v2.12 was built with Go 1.26 and cannot lint a 1.27 module, so the CI pin moves to v2.13, which resolves to the latest upstream release. The only new finding is the modernize rule preferring errors.AsType over errors.As, which is fixed in tlog.
