### PR TITLE
feat(secant): add SignBundleDigest for fetch-free single-digest signing

### DIFF
--- a/pkg/private/secant/bundlesign.go
+++ b/pkg/private/secant/bundlesign.go
@@ -18,6 +18,7 @@ import (
 	"github.com/chainguard-dev/terraform-provider-cosign/pkg/private/secant/types"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	ggcrtypes "github.com/google/go-containerregistry/pkg/v1/types"
@@ -204,8 +205,9 @@ func (bs *BundleSigner) SignContent(ctx context.Context, content sign.Content) (
 	return bundle, nil
 }
 
-// contentSigner is the part of BundleSigner that SignBundle consumes — the
-// seam that lets tests drive the walk and write fan-out without Fulcio.
+// contentSigner is the part of BundleSigner that the bundle signing paths
+// consume — the seam that lets tests drive the walk and the per-digest write
+// without Fulcio.
 type contentSigner interface {
 	SignContent(ctx context.Context, content sign.Content) ([]byte, error)
 }
@@ -218,6 +220,10 @@ type contentSigner interface {
 // semantics of Sign: APPEND (or empty) always writes, SKIPSAME skips when an
 // existing referrer has an identical payload, REPLACE deletes existing
 // referrers with matching predicate type before writing.
+//
+// SignBundle fetches each image to walk it, so every digest in imgs must
+// already exist in the registry. Callers that enumerate manifests themselves,
+// or that sign concurrently with a push, use SignBundleDigest.
 func SignBundle(ctx context.Context, conflict string, annotations map[string]any, signer *BundleSigner, imgs []name.Digest, ropt []remote.Option) error {
 	return signBundle(ctx, conflict, annotations, signer, imgs, ropt)
 }
@@ -232,11 +238,18 @@ func signBundle(ctx context.Context, conflict string, annotations map[string]any
 		}
 
 		if err := walk.SignedEntity(ctx, se, func(ctx context.Context, se oci.SignedEntity) error {
-			d, err := se.Digest()
-			if err != nil {
-				return fmt.Errorf("computing digest: %w", err)
+			// The walk yields oci.SignedImage or oci.SignedImageIndex, both
+			// Describable, so the referrer subject comes from what the walk
+			// already fetched rather than a HEAD per entity.
+			describable, ok := se.(partial.Describable)
+			if !ok {
+				return fmt.Errorf("unexpected signed entity type %T", se)
 			}
-			return signBundleDigest(ctx, conflict, annotations, signer, ref.Context().Digest(d.String()), ropt, opts)
+			subjectDesc, err := partial.Descriptor(describable)
+			if err != nil {
+				return fmt.Errorf("describing entity: %w", err)
+			}
+			return signBundleDigest(ctx, conflict, annotations, signer, ref.Context().Digest(subjectDesc.Digest.String()), subjectDesc, ropt, opts)
 		}); err != nil {
 			return fmt.Errorf("recursively signing: %w", err)
 		}
@@ -245,12 +258,25 @@ func signBundle(ctx context.Context, conflict string, annotations map[string]any
 	return nil
 }
 
+// SignBundleDigest signs exactly the given digest with a sign-predicate
+// bundle written as an OCI referrer, without recursing into an index's
+// children. Because the subject manifest is never fetched — the referrer's
+// subject descriptor is synthesized from the digest — the digest does not
+// need to exist in the registry yet. conflict has the same semantics as
+// SignBundle.
+func SignBundleDigest(ctx context.Context, conflict string, annotations map[string]any, signer *BundleSigner, digest name.Digest, ropt []remote.Option) error {
+	opts := []ociremote.Option{ociremote.WithRemoteOptions(ropt...)}
+	return signBundleDigest(ctx, conflict, annotations, signer, digest, nil, ropt, opts)
+}
+
 // signBundleDigest signs exactly one digest with a sign-predicate bundle,
-// applying the conflict policy against its existing referrers.
-func signBundleDigest(ctx context.Context, conflict string, annotations map[string]any, signer contentSigner, digest name.Digest, ropt []remote.Option, opts []ociremote.Option) error {
-	digestParts := strings.Split(digest.DigestStr(), ":")
-	if len(digestParts) != 2 {
-		return fmt.Errorf("unable to parse digest %s", digest.DigestStr())
+// applying the conflict policy against its existing referrers. subjectDesc,
+// when non-nil, is used verbatim as the referrer's subject descriptor; nil
+// synthesizes a digest-only one. Neither reads the subject.
+func signBundleDigest(ctx context.Context, conflict string, annotations map[string]any, signer contentSigner, digest name.Digest, subjectDesc *v1.Descriptor, ropt []remote.Option, opts []ociremote.Option) error {
+	h, err := v1.NewHash(digest.DigestStr())
+	if err != nil {
+		return fmt.Errorf("parsing digest %q: %w", digest.String(), err)
 	}
 
 	annoStruct, err := structpb.NewStruct(annotations)
@@ -258,7 +284,7 @@ func signBundleDigest(ctx context.Context, conflict string, annotations map[stri
 		return fmt.Errorf("converting annotations to protobuf struct: %w", err)
 	}
 	subject := intotov1.ResourceDescriptor{
-		Digest:      map[string]string{digestParts[0]: digestParts[1]},
+		Digest:      map[string]string{h.Algorithm: h.Hex},
 		Annotations: annoStruct,
 	}
 
@@ -292,7 +318,10 @@ func signBundleDigest(ctx context.Context, conflict string, annotations map[stri
 		return fmt.Errorf("signing bundle for %q: %w", digest.String(), err)
 	}
 
-	if err := writeBundleReferrer(digest, bundleBytes, ctypes.CosignSignPredicateType, nil, ropt); err != nil {
+	if subjectDesc == nil {
+		subjectDesc = &v1.Descriptor{Digest: h}
+	}
+	if err := writeBundleReferrer(digest, bundleBytes, ctypes.CosignSignPredicateType, subjectDesc, ropt); err != nil {
 		return fmt.Errorf("writing sign bundle for %q: %w", digest.String(), err)
 	}
 

--- a/pkg/private/secant/bundlesign_test.go
+++ b/pkg/private/secant/bundlesign_test.go
@@ -1,6 +1,7 @@
 package secant
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -10,10 +11,16 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	intotov1 "github.com/in-toto/attestation/go/v1"
@@ -167,7 +174,7 @@ func TestSignBundleWalksIndexChildren(t *testing.T) {
 
 	for _, referrersSupport := range []bool{true, false} {
 		t.Run(fmt.Sprintf("referrersSupport=%t", referrersSupport), func(t *testing.T) {
-			repo := newTestRepo(t, referrersSupport)
+			repo, rec := newRecordingTestRepo(t, referrersSupport)
 
 			idx, err := random.Index(1024, 1, 2)
 			if err != nil {
@@ -189,6 +196,7 @@ func TestSignBundleWalksIndexChildren(t *testing.T) {
 			for _, m := range im.Manifests {
 				digests = append(digests, repo.Digest(m.Digest.String()))
 			}
+			rec.reset()
 
 			signer := &fakeContentSigner{t: t}
 			if err := signBundle(ctx, SkipSame, nil, signer, digests[:1], nil); err != nil {
@@ -198,24 +206,33 @@ func TestSignBundleWalksIndexChildren(t *testing.T) {
 			// The walk signs the index and each of its children, and every
 			// bundle's statement names the entity it is attached to.
 			for _, d := range digests {
-				statements := signBundleStatements(t, d)
-				if len(statements) != 1 {
-					t.Errorf("got %d sign bundles for %s, want 1", len(statements), d)
-					continue
-				}
-				statement := &intotov1.Statement{}
-				if err := protojson.Unmarshal(statements[0], statement); err != nil {
-					t.Fatalf("unmarshaling statement for %s: %v", d, err)
-				}
-				if got := len(statement.Subject); got != 1 {
-					t.Fatalf("got %d statement subjects for %s, want 1", got, d)
-				}
-				if got, want := "sha256:"+statement.Subject[0].Digest["sha256"], d.DigestStr(); got != want {
-					t.Errorf("statement subject = %s, want %s", got, want)
-				}
+				assertOneSignBundle(t, d)
 			}
 			if signer.calls != len(digests) {
 				t.Errorf("got %d sign operations, want %d", signer.calls, len(digests))
+			}
+
+			// The walk already fetched every entity, so the referrer subject
+			// descriptors come from those fetches — no HEAD per entity — and
+			// carry the media type, digest and size a HEAD would have returned.
+			for _, d := range digests {
+				if heads := rec.subjectRequests(d, http.MethodHead); len(heads) != 0 {
+					t.Errorf("subject %s was HEADed: %v", d, heads)
+				}
+			}
+			for _, d := range digests {
+				want, err := remote.Head(d)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, got := range signBundleSubjects(t, d) {
+					if got == nil {
+						t.Fatalf("sign bundle for %s has no subject descriptor", d)
+					}
+					if got.MediaType != want.MediaType || got.Digest != want.Digest || got.Size != want.Size {
+						t.Errorf("sign bundle subject for %s = %+v, want {%s %s %d}", d, *got, want.MediaType, want.Digest, want.Size)
+					}
+				}
 			}
 
 			// A SKIPSAME re-run finds every bundle already in place and signs
@@ -252,6 +269,30 @@ func TestSignBundleWalksIndexChildren(t *testing.T) {
 	}
 }
 
+// signBundleSubjects returns the subject descriptor of each sign-predicate
+// bundle referrer manifest attached to d.
+func signBundleSubjects(t *testing.T, d name.Digest) []*v1.Descriptor {
+	t.Helper()
+
+	matching, err := matchingBundleReferrers(d, ctypes.CosignSignPredicateType, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subjects := make([]*v1.Descriptor, 0, len(matching))
+	for _, m := range matching {
+		desc, err := remote.Get(d.Context().Digest(m.Digest.String()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mf, err := v1.ParseManifest(bytes.NewReader(desc.Manifest))
+		if err != nil {
+			t.Fatal(err)
+		}
+		subjects = append(subjects, mf.Subject)
+	}
+	return subjects
+}
+
 // signBundleStatements returns the DSSE statement payload of each
 // sign-predicate bundle referrer attached to d.
 func signBundleStatements(t *testing.T, d name.Digest) [][]byte {
@@ -270,4 +311,202 @@ func signBundleStatements(t *testing.T, d name.Digest) [][]byte {
 		payloads = append(payloads, p)
 	}
 	return payloads
+}
+
+// recordingRegistry logs every request served by a test registry, so a test
+// can prove which manifests the code under test did not touch.
+type recordingRegistry struct {
+	mu   sync.Mutex
+	reqs []string
+}
+
+// reset discards requests recorded so far, so a test can separate its own
+// setup traffic from the code under test.
+func (r *recordingRegistry) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reqs = nil
+}
+
+func (r *recordingRegistry) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reqs = append(r.reqs, req.Method+" "+req.URL.Path)
+}
+
+// subjectRequests returns the requests with any of the given methods against
+// the subject manifest itself, addressed by digest — as opposed to its
+// referrers or the sha256-<digest> fallback-tag index, which the writer
+// legitimately reads.
+func (r *recordingRegistry) subjectRequests(d name.Digest, methods ...string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	path := "/v2/" + d.Context().RepositoryStr() + "/manifests/" + d.DigestStr()
+	var reqs []string
+	for _, req := range r.reqs {
+		for _, m := range methods {
+			if req == m+" "+path {
+				reqs = append(reqs, req)
+			}
+		}
+	}
+	return reqs
+}
+
+func newRecordingTestRepo(t *testing.T, referrersSupport bool) (name.Repository, *recordingRegistry) {
+	t.Helper()
+
+	rec := &recordingRegistry{}
+	reg := registry.New(registry.WithReferrersSupport(referrersSupport))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		rec.record(req)
+		reg.ServeHTTP(w, req)
+	}))
+	t.Cleanup(srv.Close)
+
+	repo, err := name.NewRepository(strings.TrimPrefix(srv.URL, "http://") + "/test-repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, rec
+}
+
+// assertOneSignBundle checks that exactly one sign-predicate bundle is
+// attached to d and that its statement names d as the subject.
+func assertOneSignBundle(t *testing.T, d name.Digest) {
+	t.Helper()
+
+	statements := signBundleStatements(t, d)
+	if len(statements) != 1 {
+		t.Fatalf("got %d sign bundles for %s, want 1", len(statements), d)
+	}
+	statement := &intotov1.Statement{}
+	if err := protojson.Unmarshal(statements[0], statement); err != nil {
+		t.Fatalf("unmarshaling statement for %s: %v", d, err)
+	}
+	if got := len(statement.Subject); got != 1 {
+		t.Fatalf("got %d statement subjects for %s, want 1", got, d)
+	}
+	if got, want := "sha256:"+statement.Subject[0].Digest["sha256"], d.DigestStr(); got != want {
+		t.Errorf("statement subject = %s, want %s", got, want)
+	}
+}
+
+// TestSignBundleDigestSignsUnpushedSubjectWithoutFetching pins the contract
+// that distinguishes SignBundleDigest from SignBundle: it signs a digest whose
+// manifest is not in the registry yet and never reads the subject manifest,
+// so a caller may sign while the push is still in flight.
+func TestSignBundleDigestSignsUnpushedSubjectWithoutFetching(t *testing.T) {
+	ctx := context.Background()
+
+	for _, referrersSupport := range []bool{true, false} {
+		t.Run(fmt.Sprintf("referrersSupport=%t", referrersSupport), func(t *testing.T) {
+			repo, rec := newRecordingTestRepo(t, referrersSupport)
+
+			// Deliberately not pushed: the subject exists only as a digest.
+			img, err := random.Image(1024, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			h, err := img.Digest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			d := repo.Digest(h.String())
+
+			signer := &fakeContentSigner{t: t}
+			if err := signBundleDigest(ctx, SkipSame, nil, signer, d, nil, nil, nil); err != nil {
+				t.Fatalf("signBundleDigest() = %v", err)
+			}
+			assertOneSignBundle(t, d)
+			if signer.calls != 1 {
+				t.Errorf("got %d sign operations, want 1", signer.calls)
+			}
+
+			// A SKIPSAME re-run finds the bundle in place and signs nothing.
+			signer.calls = 0
+			if err := signBundleDigest(ctx, SkipSame, nil, signer, d, nil, nil, nil); err != nil {
+				t.Fatalf("signBundleDigest() re-run = %v", err)
+			}
+			if signer.calls != 0 {
+				t.Errorf("re-run performed %d sign operations, want 0", signer.calls)
+			}
+			assertOneSignBundle(t, d)
+
+			// REPLACE re-signs and still converges on one bundle.
+			signer.calls = 0
+			if err := signBundleDigest(ctx, Replace, nil, signer, d, nil, nil, nil); err != nil {
+				t.Fatalf("signBundleDigest() REPLACE = %v", err)
+			}
+			if signer.calls != 1 {
+				t.Errorf("REPLACE run performed %d sign operations, want 1", signer.calls)
+			}
+			assertOneSignBundle(t, d)
+
+			// None of the three runs read the subject manifest.
+			if reads := rec.subjectRequests(d, http.MethodGet, http.MethodHead); len(reads) != 0 {
+				t.Errorf("subject manifest was read: %v", reads)
+			}
+
+			// Once the publish lands, the bundle is attached to the real
+			// manifest: the registry indexes referrers by the subject digest.
+			if err := remote.Write(repo.Tag("latest"), img); err != nil {
+				t.Fatal(err)
+			}
+			assertOneSignBundle(t, d)
+		})
+	}
+}
+
+// TestSignBundleDigestDoesNotWalkIndex is the counterpart of
+// TestSignBundleWalksIndexChildren: handed an index, SignBundleDigest signs
+// the index alone and leaves its children untouched and unread. Callers that
+// enumerate their own children sign each one explicitly.
+func TestSignBundleDigestDoesNotWalkIndex(t *testing.T) {
+	ctx := context.Background()
+	repo, rec := newRecordingTestRepo(t, true)
+
+	idx, err := random.Index(1024, 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.WriteIndex(repo.Tag("latest"), idx); err != nil {
+		t.Fatal(err)
+	}
+	h, err := idx.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	im, err := idx.IndexManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := repo.Digest(h.String())
+	children := make([]name.Digest, 0, len(im.Manifests))
+	for _, m := range im.Manifests {
+		children = append(children, repo.Digest(m.Digest.String()))
+	}
+	// WriteIndex above probes manifests before pushing; only the code under
+	// test's traffic is of interest.
+	rec.reset()
+
+	signer := &fakeContentSigner{t: t}
+	if err := signBundleDigest(ctx, SkipSame, nil, signer, d, nil, nil, nil); err != nil {
+		t.Fatalf("signBundleDigest() = %v", err)
+	}
+	assertOneSignBundle(t, d)
+	if signer.calls != 1 {
+		t.Errorf("got %d sign operations, want 1", signer.calls)
+	}
+	for _, c := range children {
+		if got := len(signBundleStatements(t, c)); got != 0 {
+			t.Errorf("got %d sign bundles for child %s, want 0", got, c)
+		}
+		if reads := rec.subjectRequests(c, http.MethodGet, http.MethodHead); len(reads) != 0 {
+			t.Errorf("child manifest %s was read: %v", c, reads)
+		}
+	}
+	if reads := rec.subjectRequests(d, http.MethodGet, http.MethodHead); len(reads) != 0 {
+		t.Errorf("index manifest was read: %v", reads)
+	}
 }

--- a/pkg/private/secant/writereferrer_test.go
+++ b/pkg/private/secant/writereferrer_test.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -41,13 +39,7 @@ func setupTestRepo(t *testing.T) name.Repository {
 func newTestRepo(t *testing.T, referrersSupport bool) name.Repository {
 	t.Helper()
 
-	srv := httptest.NewServer(registry.New(registry.WithReferrersSupport(referrersSupport)))
-	t.Cleanup(srv.Close)
-
-	repo, err := name.NewRepository(strings.TrimPrefix(srv.URL, "http://") + "/test-repo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	repo, _ := newRecordingTestRepo(t, referrersSupport)
 	return repo
 }
 


### PR DESCRIPTION
Since #623 (v0.4.20), `SignBundle` starts every digest with `ociremote.SignedEntity` and an index walk. That is the right shape for the Terraform `cosign_sign` resource, which only knows the index and signs an image that already exists. It is the wrong shape for a caller that builds an image, enumerates every manifest it produced, and signs while the push is still in flight: the fetch races the manifest PUT, fails with `MANIFEST_UNKNOWN`, and the whole call aborts before signing anything, even though `SignDigest` on the legacy path handles exactly that pattern by never fetching.

This adds `SignBundleDigest`, the bundle counterpart of `SignDigest`: it signs exactly the given digest with no fetch and no walk, and synthesizes the referrer's subject descriptor from the digest so the write never HEADs a subject that may not exist yet.

`SignBundle` itself is unchanged in behavior, apart from documenting that its digests must already exist, and (per review) it now takes each entity's subject descriptor from the `oci.SignedEntity` the walk already fetched instead of issuing a second HEAD per entity, so the sign path makes no subject request on either entry point.

`AttestBundle` is unaffected by #623 but is not immune to the same race: with a nil `Statement.SubjectDescriptor` the referrer write still HEADs the subject after `SignContent`. Callers that sign concurrently with a push should set a digest-only `SubjectDescriptor` on their statements; this PR does not change that path.

Key changes:
- **`SignBundleDigest`**: new exported entry point; the shared per-digest helper takes a subject descriptor, synthesizing a digest-only one when handed `nil`.
- **`SignBundle`**: builds the referrer subject descriptor from the walked entity (media type, digest, size), dropping the per-entity HEAD.
- **Tests**: a request-recording registry proves the subject manifest is never read while signing an unpushed digest (referrers API and fallback-tag modes), that SKIPSAME re-runs are no-ops and REPLACE converges on one bundle, that an index digest is signed alone without touching its children, and that the walk issues no HEAD while its written descriptors still match `remote.Head`.

Assisted by Claude Fable 5.1
